### PR TITLE
Adding FFT tests

### DIFF
--- a/quasielasticbayes/Four_main.f90
+++ b/quasielasticbayes/Four_main.f90
@@ -4,11 +4,17 @@
       INCLUDE 'options.f90'
       
 	  INTEGER N(1), ISIGN, NDIM, IFORM
-	  COMPLEX DATA(4), y_out(4)
+	  COMPLEX DATA(4098), y_out(4098)
       real x_in(m_d), y_in(m_d), e_in(m_d)
 cf2py intent(in) :: DATA, N, ISIGN, NDIM, IFORM
 cf2py intent(out) :: y_out                               !real parameters
       y_out = DATA
+      OPEN(UNIT=11,FILE='C:\Users\BTR75544\work\f70.txt')
+      WRITE(11,*) 'hi ', ISIGN	  
+      DO KK = 1,8
+      WRITE(11,*) y_out(KK), "   ", DATA(kk),"   ", KK
+      END DO
+      CLOSE(11)	  
 	  CALL FOUR2(y_out,N,NDIM,ISIGN,IFORM)
       RETURN
       END

--- a/quasielasticbayes/Four_main.f90
+++ b/quasielasticbayes/Four_main.f90
@@ -8,13 +8,7 @@
       real x_in(m_d), y_in(m_d), e_in(m_d)
 cf2py intent(in) :: DATA, N, ISIGN, NDIM, IFORM
 cf2py intent(out) :: y_out                               !real parameters
-      y_out = DATA
-      OPEN(UNIT=11,FILE='C:\Users\BTR75544\work\f70.txt')
-      WRITE(11,*) 'hi ', ISIGN	  
-      DO KK = 1,8
-      WRITE(11,*) y_out(KK), "   ", DATA(kk),"   ", KK
-      END DO
-      CLOSE(11)	  
-	  CALL FOUR2(y_out,N,NDIM,ISIGN,IFORM)
+      y_out = DATA	  
+	CALL FOUR2(y_out,N,NDIM,ISIGN,IFORM)
       RETURN
       END

--- a/quasielasticbayes/Four_main.f90
+++ b/quasielasticbayes/Four_main.f90
@@ -1,0 +1,14 @@
+      SUBROUTINE four(DATA,N,NDIM,ISIGN,IFORM, y_out)
+      INCLUDE 'mod_data.f90'
+      INCLUDE 'mod_files.f90'
+      INCLUDE 'options.f90'
+      
+	  INTEGER N(1), ISIGN, NDIM, IFORM
+	  COMPLEX DATA(4), y_out(4)
+      real x_in(m_d), y_in(m_d), e_in(m_d)
+cf2py intent(in) :: DATA, N, ISIGN, NDIM, IFORM
+cf2py intent(out) :: y_out                               !real parameters
+      y_out = DATA
+	  CALL FOUR2(y_out,N,NDIM,ISIGN,IFORM)
+      RETURN
+      END

--- a/quasielasticbayes/test/FFT_test.py
+++ b/quasielasticbayes/test/FFT_test.py
@@ -3,7 +3,6 @@ import os.path
 import unittest
 import numpy as np
 from quasielasticbayes.testing import load_json
-
 from quasielasticbayes.Four import four
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 
@@ -14,13 +13,93 @@ class FFTTest(unittest.TestCase):
     The output is based on running BayesQuasi algorithm in mantid 6.2
     with the inputs taken from the BayesQuasiTest unit test
     """
-
-    def test_FFT(self):
+	# P = +1, N = -1, Z = 0
+    def test_FFT_PPN_Re(self):
         # reference inputs
-        x = np.asarray([k for k in range(4)])
-        y = np.cos(x)
-        out = four(y,4,1,1,1)
-        print(out)
+        x = np.asarray([np.complex(0.0) for _ in range(4098)])
+        for j in range(8):
+                x[j]=np.complex(np.cos(float(j)+0.1), 0)
+        y = x
+        out = four(y,8,1,1,-1)
+        dp= 3
+        self.assertAlmostEqual(-1.6806+3.6243j, out[0], dp)
+        self.assertAlmostEqual(1.4300-0.4846j, out[1], dp)
+        self.assertAlmostEqual(0.5016-0.4846j, out[2], dp)
+        self.assertAlmostEqual(1.4299+3.6243j, out[3], dp)
+        self.assertAlmostEqual(-0.5748, out[4], dp)
+        self.assertAlmostEqual(0.3780, out[5], dp)
+        self.assertAlmostEqual(0.9833, out[6], dp)
+        self.assertAlmostEqual(0.6845, out[7], dp)
+
+    # In the code it only seems to use 1,-1,-1 and 1,1,0
+    # So these are the two we will test
+    def test_FFT_PNN_Re(self):
+        # reference inputs
+        x = np.asarray([np.complex(0.0) for _ in range(4098)])
+        for j in range(8):
+                x[j]=np.complex(np.cos(float(j)+0.1), 0)
+        y = x
+        out = four(y,8,1,-1,-1)
+        dp= 3
+        self.assertAlmostEqual(-1.681+3.6243j, out[0], dp)
+        self.assertAlmostEqual(1.4299-0.4846j, out[1], dp)
+        self.assertAlmostEqual(0.5016-0.4846j, out[2], dp)
+        self.assertAlmostEqual(1.4299+3.6243j, out[3], dp)
+        self.assertAlmostEqual(-0.5748, out[4], dp)
+        self.assertAlmostEqual(0.37800, out[5], dp)
+        self.assertAlmostEqual(0.9833, out[6], dp)
+        self.assertAlmostEqual(0.6845, out[7], dp)
+		
+    def test_FFT_PNN_Im(self):
+        # reference inputs
+        x = np.asarray([np.complex(0.0) for _ in range(4098)])
+        for j in range(8):
+                x[j]=np.complex(np.cos(float(j)+0.1), j)
+        y = x
+        out = four(y,8,1,-1,-1)
+        dp= 3
+        self.assertAlmostEqual(-1.681+13.2812j, out[0], dp)
+        self.assertAlmostEqual(-2.5701+1.1722j, out[1], dp)
+        self.assertAlmostEqual(0.5016-2.1415j, out[2], dp)
+        self.assertAlmostEqual(5.4299-6.0326j, out[3], dp)
+        self.assertAlmostEqual(-0.5748+4j, out[4], dp)
+        self.assertAlmostEqual(0.3780+5j, out[5], dp)
+        self.assertAlmostEqual(0.9833+6j, out[6], dp)
+        self.assertAlmostEqual(0.6845+7j, out[7], dp)	
+		
+    def test_FFT_PPZ_Re(self):
+        # reference inputs
+        x = np.asarray([np.complex(0.0) for _ in range(4098)])
+        for j in range(8):
+                x[j]=np.complex(np.cos(float(j)+0.1), 0)
+        y = x
+        out = four(y,8,1,1,0)
+        dp= 3
+        self.assertAlmostEqual(-0.0553, out[0], dp)
+        self.assertAlmostEqual(1.5000+1.4527j, out[1], dp)
+        self.assertAlmostEqual(1.0357, out[2], dp)
+        self.assertAlmostEqual(1.5000-1.4527j, out[3], dp)
+        self.assertAlmostEqual(-0.0554, out[4], dp)
+        self.assertAlmostEqual(0.3780, out[5], dp)
+        self.assertAlmostEqual(0.9833, out[6], dp)
+        self.assertAlmostEqual(0.6845, out[7], dp)		
+		
+    def test_FFT_PPZ_Im(self):
+        # reference inputs
+        x = np.asarray([np.complex(0.0) for _ in range(4098)])
+        for j in range(8):
+                x[j]=np.complex(np.cos(float(j)+0.1), j)
+        y = x
+        out = four(y,8,1,1,0)
+        dp= 3
+        self.assertAlmostEqual(5.9446, out[0], dp)
+        self.assertAlmostEqual(1.4999-1.3757j, out[1], dp)
+        self.assertAlmostEqual(1.0357-2j, out[2], dp)
+        self.assertAlmostEqual(1.4999-4.2812j, out[3], dp)
+        self.assertAlmostEqual(-6.0554, out[4], dp)
+        self.assertAlmostEqual(0.3780+5j, out[5], dp)
+        self.assertAlmostEqual(0.9833+6j, out[6], dp)
+        self.assertAlmostEqual(0.6845+7j, out[7], dp)	
 
 if __name__ == '__main__':
     unittest.main()

--- a/quasielasticbayes/test/FFT_test.py
+++ b/quasielasticbayes/test/FFT_test.py
@@ -1,0 +1,26 @@
+"""Characterization tests for QLres module"""
+import os.path
+import unittest
+import numpy as np
+from quasielasticbayes.testing import load_json
+
+from quasielasticbayes.Four import four
+DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
+
+
+class FFTTest(unittest.TestCase):
+    """
+    Characterization tests using inputs that have been accepted as correct.
+    The output is based on running BayesQuasi algorithm in mantid 6.2
+    with the inputs taken from the BayesQuasiTest unit test
+    """
+
+    def test_FFT(self):
+        # reference inputs
+        x = np.asarray([k for k in range(4)])
+        y = np.cos(x)
+        out = four(y,4,1,1,1)
+        print(out)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/quasielasticbayes/test/Four_test.py
+++ b/quasielasticbayes/test/Four_test.py
@@ -1,24 +1,20 @@
-"""Characterization tests for QLres module"""
-import os.path
+"""Characterization tests for Four module"""
 import unittest
 import numpy as np
-from quasielasticbayes.testing import load_json
+#from quasielasticbayes.testing import load_json will add this later
 from quasielasticbayes.Four import four
-DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 
 
-class FFTTest(unittest.TestCase):
+class FourTest(unittest.TestCase):
     """
-    Characterization tests using inputs that have been accepted as correct.
-    The output is based on running BayesQuasi algorithm in mantid 6.2
-    with the inputs taken from the BayesQuasiTest unit test
+    Characterization tests for the four Fortran module
     """
 	# P = +1, N = -1, Z = 0
-    def test_FFT_PPN_Re(self):
+    def test_Four_PPN_Re(self):
         # reference inputs
-        x = np.asarray([np.complex(0.0) for _ in range(4098)])
-        for j in range(8):
-                x[j]=np.complex(np.cos(float(j)+0.1), 0)
+        x = np.zeros(4098, dtype=complex)
+        nonzero_entries = 8
+        x[:nonzero_entries] = [complex(np.cos(float(i)+0.1), 0.) for i in range(nonzero_entries)]
         y = x
         out = four(y,8,1,1,-1)
         dp= 3
@@ -33,11 +29,10 @@ class FFTTest(unittest.TestCase):
 
     # In the code it only seems to use 1,-1,-1 and 1,1,0
     # So these are the two we will test
-    def test_FFT_PNN_Re(self):
-        # reference inputs
-        x = np.asarray([np.complex(0.0) for _ in range(4098)])
-        for j in range(8):
-                x[j]=np.complex(np.cos(float(j)+0.1), 0)
+    def test_Four_PNN_Re(self):
+        x = np.zeros(4098, dtype=complex)
+        nonzero_entries = 8
+        x[:nonzero_entries] = [complex(np.cos(float(i)+0.1), 0.) for i in range(nonzero_entries)]
         y = x
         out = four(y,8,1,-1,-1)
         dp= 3
@@ -50,11 +45,10 @@ class FFTTest(unittest.TestCase):
         self.assertAlmostEqual(0.9833, out[6], dp)
         self.assertAlmostEqual(0.6845, out[7], dp)
 		
-    def test_FFT_PNN_Im(self):
-        # reference inputs
-        x = np.asarray([np.complex(0.0) for _ in range(4098)])
-        for j in range(8):
-                x[j]=np.complex(np.cos(float(j)+0.1), j)
+    def test_Four_PNN_Im(self):
+        x = np.zeros(4098, dtype=complex)
+        nonzero_entries = 8
+        x[:nonzero_entries] = [complex(np.cos(float(i)+0.1), i) for i in range(nonzero_entries)]
         y = x
         out = four(y,8,1,-1,-1)
         dp= 3
@@ -67,11 +61,10 @@ class FFTTest(unittest.TestCase):
         self.assertAlmostEqual(0.9833+6j, out[6], dp)
         self.assertAlmostEqual(0.6845+7j, out[7], dp)	
 		
-    def test_FFT_PPZ_Re(self):
-        # reference inputs
-        x = np.asarray([np.complex(0.0) for _ in range(4098)])
-        for j in range(8):
-                x[j]=np.complex(np.cos(float(j)+0.1), 0)
+    def test_Four_PPZ_Re(self):
+        x = np.zeros(4098, dtype=complex)
+        nonzero_entries = 8
+        x[:nonzero_entries] = [complex(np.cos(float(i)+0.1),0.) for i in range(nonzero_entries)]
         y = x
         out = four(y,8,1,1,0)
         dp= 3
@@ -84,11 +77,10 @@ class FFTTest(unittest.TestCase):
         self.assertAlmostEqual(0.9833, out[6], dp)
         self.assertAlmostEqual(0.6845, out[7], dp)		
 		
-    def test_FFT_PPZ_Im(self):
-        # reference inputs
-        x = np.asarray([np.complex(0.0) for _ in range(4098)])
-        for j in range(8):
-                x[j]=np.complex(np.cos(float(j)+0.1), j)
+    def test_Four_PPZ_Im(self):
+        x = np.zeros(4098, dtype=complex)
+        nonzero_entries = 8
+        x[:nonzero_entries] = [complex(np.cos(float(i)+0.1),i) for i in range(nonzero_entries)]
         y = x
         out = four(y,8,1,1,0)
         dp= 3

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,9 @@ module_source_map = {
                                'QLdata_subs.f90',
                                'Bayes.f90',
                                'Four.f90',
-                               'Util.f90']
+                               'Util.f90'],
+    f'{PACKAGE_NAME}.Four': ['Four_main.f90',
+                               'Four.f90']							   
 }
 extensions = [create_fortran_extension(name, source_paths(PurePosixPath('quasielasticbayes'), sources)) for
               name, sources in module_source_map.items()]


### PR DESCRIPTION
Since FFT's are a vital part of the analysis (being used many times). I have created a package so we can test the FFT code. I have written tests based on the combinations that are used in the rest of the code base (1,-1,-1 and 1, 1, 0 I got these using grep for FOUR2). 

This will also allow us to easily test any replacement system. 

Fixes #5