### PR TITLE
Added user guess to qldata and update FWHM in se

### DIFF
--- a/src/quasielasticbayes/v2_python/fit_functions/quasielastic_function.py
+++ b/src/quasielasticbayes/v2_python/fit_functions/quasielastic_function.py
@@ -4,6 +4,7 @@ from quasielasticbayes.v2.functions.base import BaseFitFunction
 from quasielasticbayes.v2.functions.delta import Delta
 from numpy import ndarray
 from typing import Dict, List
+import copy
 
 
 """
@@ -35,7 +36,7 @@ class QEFunction(BaseFitFunction):
         :param end_x: the end of the fitting range
         """
         self._N_peaks = 0
-        self.BG = bg_function
+        self.BG = copy.copy(bg_function)
         self.BG.add_to_prefix(self.prefix + 'f1')
         self.conv = ConvolutionWithResolution(r_x, r_y, start_x,
                                               end_x, self.prefix + 'f2')
@@ -46,6 +47,17 @@ class QEFunction(BaseFitFunction):
             delta = Delta('')
             self.conv.add_function(delta)
         super().__init__(0, self.prefix)
+
+    def update_x_range(self, new_x: ndarray) -> None:
+        """
+        The sampling of the resolution function can make
+        a big difference to the quality of the function.
+        This is because of sampling issues. To solve
+        this problem a user can update the x (and y)
+        ranges using this method.
+        :param new_x: the new x range (y is interpolated)
+        """
+        self.conv.update_x_range(new_x)
 
     @property
     def N_params(self) -> int:

--- a/src/quasielasticbayes/v2_python/fit_functions/stretch_exp.py
+++ b/src/quasielasticbayes/v2_python/fit_functions/stretch_exp.py
@@ -140,7 +140,7 @@ class StretchExp(BaseFitFunction):
         :param tau: tau parameter
         :return FWHM
         """
-        return PLANCK_CONSTANT/(2.*np.pi*tau)
+        return 2.*PLANCK_CONSTANT/(2.*np.pi*tau)
 
     @staticmethod
     def tau(FWHM: float) -> float:
@@ -150,7 +150,7 @@ class StretchExp(BaseFitFunction):
         :param FWHM: full width half maximum
         :return tau parameter
         """
-        return PLANCK_CONSTANT/(2.*np.pi*FWHM)
+        return 2.*PLANCK_CONSTANT/(2.*np.pi*FWHM)
 
     def report(self, report_dict: Dict[str, List[float]], a: float, x0: float,
                tau, beta) -> Dict[str, List[float]]:

--- a/src/quasielasticbayes/v2_python/qldata_main.py
+++ b/src/quasielasticbayes/v2_python/qldata_main.py
@@ -15,7 +15,7 @@ def ql_data_main(sample: Dict[str, ndarray], res: Dict[str, ndarray],
                  elastic: bool,
                  results: Dict[str, ndarray],
                  params: List[float] = None) -> (Dict[str, ndarray],
-                                                 List[float]):
+                                                 ndarray):
     """
     The main function for calculating Qldata.
     Steps are:
@@ -35,7 +35,7 @@ def ql_data_main(sample: Dict[str, ndarray], res: Dict[str, ndarray],
     :param elastic: if to include the elastic peak
     :param results: dict of results
     :param params: initial values, if None (default) a guess will be made
-    :result dict of the fit parameters and an array of the loglikelihoods
+    :result dict of the fit parameters and the x range that was used
     """
     # step 0
     BG = get_background_function(BG_type)
@@ -60,7 +60,6 @@ def ql_data_main(sample: Dict[str, ndarray], res: Dict[str, ndarray],
         guess = func.get_guess()
     # loop doing steps 2 to 8
     params = guess
-    y = None
     for N in range(1, max_num_peaks+1):
         func.add_single_lorentzian()
 
@@ -70,9 +69,6 @@ def ql_data_main(sample: Dict[str, ndarray], res: Dict[str, ndarray],
                                                         func, params,
                                                         lower, upper)
         params = list(params)
-
-        if N == 1:
-            y = func(new_x, *params)
 
         results = func.report(results, *params)
 
@@ -86,4 +82,4 @@ def ql_data_main(sample: Dict[str, ndarray], res: Dict[str, ndarray],
                                                 hess_det,
                                                 func.N_peaks, beta)]
 
-    return results, new_x, y
+    return results, new_x

--- a/test/fit_functions/SE_test.py
+++ b/test/fit_functions/SE_test.py
@@ -40,7 +40,7 @@ class StretchExpTest(unittest.TestCase):
         self.assertEqual(out["Amplitude"], [1])
         self.assertEqual(out["Peak Centre"], [0.1])
         self.assertEqual(out["tau"], [10.])
-        self.assertAlmostEqual(out["FWHM"][0], 0.066, 3)
+        self.assertAlmostEqual(out["FWHM"][0], 0.132, 3)
         self.assertEqual(out["beta"], [0.5])
         self.assertEqual(out["old"], [1])
         self.assertEqual(len(out.keys()), 6)
@@ -57,7 +57,7 @@ class StretchExpTest(unittest.TestCase):
     def test_FWHM(self):
         se = StretchExp()
         FWHM = se.FWHM(3.5)
-        self.assertAlmostEqual(FWHM, 0.188, 3)
+        self.assertAlmostEqual(FWHM, 0.376, 3)
         # check round trip works
         self.assertAlmostEqual(se.tau(FWHM), 3.5)
 
@@ -68,7 +68,7 @@ class StretchExpTest(unittest.TestCase):
     def test_guess(self):
         se = StretchExp()
         guess = se.get_guess(0.2)
-        expect = [0.1, 0.0, 3.291, 0.7]
+        expect = [0.1, 0.0, 6.582, 0.7]
         self.assertEqual(len(guess), len(expect))
         for k in range(len(guess)):
             self.assertAlmostEqual(guess[k], expect[k], 3)

--- a/test/fit_functions/convolution_test.py
+++ b/test/fit_functions/convolution_test.py
@@ -19,6 +19,25 @@ def analytic(x: ndarray, amp: float, mu: float, sig: float,
 
 class ConvolutionTest(unittest.TestCase):
 
+    def test_update_resolution(self):
+        def func(x):
+            return x*x - 3.*x + 1.2
+
+        x = np.linspace(-5, 5, 6)
+        y = func(x)
+        c = conv(x, y, -6, 6)
+
+        new_x = np.linspace(-5, 5, 100)
+        c.update_x_range(new_x)
+        ry = c._ry
+        expect = func(new_x)
+        # normalise the expected values:
+        expect /= sum(expect)
+
+        self.assertEqual(len(ry), len(new_x))
+        for j in range(len(ry)):
+            self.assertAlmostEqual(ry[j], expect[j], 3)
+
     def test_conv_call(self):
         """
         Need the x range to go to zero at the ends to

--- a/test/fit_functions/qldataFunction_test.py
+++ b/test/fit_functions/qldataFunction_test.py
@@ -7,6 +7,26 @@ from quasielasticbayes.v2.functions.qldata_function import QlDataFunction
 
 class QLDataFunctionTest(unittest.TestCase):
 
+    def test_update_resolution(self):
+        def func(x):
+            return x*x - 3.*x + 1.2
+
+        x = np.linspace(-5, 5, 6)
+        y = func(x)
+        bg = LinearBG()
+        ql = QlDataFunction(bg, False, x, y, -6, 6)
+
+        new_x = np.linspace(-5, 5, 100)
+        ql.update_x_range(new_x)
+        ry = ql.conv._ry
+        expect = func(new_x)
+        # normalise the expected values:
+        expect /= sum(expect)
+
+        self.assertEqual(len(ry), len(new_x))
+        for j in range(len(ry)):
+            self.assertAlmostEqual(ry[j], expect[j], 3)
+
     def test_just_bg(self):
         x = np.linspace(0, 5, 6)
         bg = LinearBG()

--- a/test/fit_functions/qseFunction_test.py
+++ b/test/fit_functions/qseFunction_test.py
@@ -100,7 +100,7 @@ class QSEFunctionTest(unittest.TestCase):
             self.assertAlmostEqual(y[j], expect[j], 3)
 
         guess = qse.get_guess(0.1)
-        expect = [0., 0., 1., 0., 0.1, 6.582, 0.7]
+        expect = [0., 0., 1., 0., 0.1, 13.164, 0.7]
         self.assertEqual(len(guess), len(expect))
         for k in range(len(expect)):
             self.assertAlmostEqual(guess[k], expect[k], 3)
@@ -117,7 +117,7 @@ class QSEFunctionTest(unittest.TestCase):
         self.assertEqual(report["N1:f2.f2.Amplitude"], [5])
         self.assertEqual(report["N1:f2.f2.Peak Centre"], [4])
         self.assertEqual(report["N1:f2.f2.tau"], [6])
-        self.assertAlmostEqual(report["N1:f2.f2.FWHM"][0], 0.110, 3)
+        self.assertAlmostEqual(report["N1:f2.f2.FWHM"][0], 0.219, 3)
         self.assertEqual(report["N1:f2.f2.beta"], [7])
 
     def test_read_bg_and_delta_and_1se(self):
@@ -152,7 +152,7 @@ class QSEFunctionTest(unittest.TestCase):
         for j in range(len(x)):
             self.assertAlmostEqual(y[j], expect[j], 3)
 
-        expect = [0., 0., 0.1, 0., 6.582, 0.7]
+        expect = [0., 0., 0.1, 0., 13.164, 0.7]
         guess = qse.get_guess(0.1)
         self.assertEqual(len(guess), len(expect))
         for k in range(len(expect)):
@@ -167,7 +167,7 @@ class QSEFunctionTest(unittest.TestCase):
         self.assertEqual(report["N1:f2.f1.Amplitude"], [3])
         self.assertEqual(report["N1:f2.f1.Peak Centre"], [4])
         self.assertEqual(report["N1:f2.f1.tau"], [5])
-        self.assertAlmostEqual(report["N1:f2.f1.FWHM"][0], 0.132, 3)
+        self.assertAlmostEqual(report["N1:f2.f1.FWHM"][0], 0.263, 3)
         self.assertEqual(report["N1:f2.f1.beta"], [6])
 
     def test_read_bg_and_1se(self):

--- a/test/qldatav2_test.py
+++ b/test/qldatav2_test.py
@@ -1,5 +1,7 @@
 import unittest
 from quasielasticbayes.v2.QlData import ql_data_main
+from quasielasticbayes.v2.functions.qldata_function import QlDataFunction
+from quasielasticbayes.v2.functions.BG import LinearBG
 import numpy as np
 import os.path
 
@@ -20,8 +22,8 @@ class QlDataV2Test(unittest.TestCase):
         resolution = {'x': rx, 'y': ry}
         results = {}
 
-        results, new_x = ql_data_main(sample, resolution,
-                                      "linear", -0.4, 0.4, True, results)
+        results, new_x, _ = ql_data_main(sample, resolution,
+                                         "linear", -0.4, 0.4, True, results)
 
         # not from Mantid
         self.assertAlmostEqual(results['N1:loglikelihood'][0], -659.4, 2)
@@ -65,18 +67,24 @@ class QlDataV2Test(unittest.TestCase):
         resolution = {'x': rx, 'y': ry}
         results = {}
 
-        results, new_x = ql_data_main(sample, resolution,
-                                      "linear", -0.4, 0.4, True, results)
+        results, new_x, _ = ql_data_main(sample, resolution,
+                                         "linear", -0.4, 0.4, True, results)
 
         # call it again
-        results, new_x = ql_data_main(sample, resolution,
-                                      "linear", -0.4, 0.4, True, results)
+        ql = QlDataFunction(LinearBG(), True, rx, ry, -0.4, 0.4)
+        ql.add_single_lorentzian()
+        params = ql.read_from_report(results, 1, -1)
+        results, new_x, _ = ql_data_main(sample, resolution,
+                                         "linear", -0.4, 0.4, True,
+                                         results, params)
 
+        params = ql.read_from_report(results, 1, -1)
         for key in results.keys():
-            print(key, results[key])
             self.assertEqual(len(results[key]), 2)
             tmp = results[key]
-            self.assertEqual(tmp[0], tmp[1])
+
+            percentage_change = 100.*np.abs((tmp[0] - tmp[1])/tmp[0])
+            self.assertLessEqual(percentage_change, 20.)
 
 
 if __name__ == '__main__':

--- a/test/qldatav2_test.py
+++ b/test/qldatav2_test.py
@@ -22,8 +22,8 @@ class QlDataV2Test(unittest.TestCase):
         resolution = {'x': rx, 'y': ry}
         results = {}
 
-        results, new_x, _ = ql_data_main(sample, resolution,
-                                         "linear", -0.4, 0.4, True, results)
+        results, new_x = ql_data_main(sample, resolution,
+                                      "linear", -0.4, 0.4, True, results)
 
         # not from Mantid
         self.assertAlmostEqual(results['N1:loglikelihood'][0], -659.4, 2)
@@ -67,16 +67,16 @@ class QlDataV2Test(unittest.TestCase):
         resolution = {'x': rx, 'y': ry}
         results = {}
 
-        results, new_x, _ = ql_data_main(sample, resolution,
-                                         "linear", -0.4, 0.4, True, results)
+        results, new_x = ql_data_main(sample, resolution,
+                                      "linear", -0.4, 0.4, True, results)
 
         # call it again
         ql = QlDataFunction(LinearBG(), True, rx, ry, -0.4, 0.4)
         ql.add_single_lorentzian()
         params = ql.read_from_report(results, 1, -1)
-        results, new_x, _ = ql_data_main(sample, resolution,
-                                         "linear", -0.4, 0.4, True,
-                                         results, params)
+        results, new_x = ql_data_main(sample, resolution,
+                                      "linear", -0.4, 0.4, True,
+                                      results, params)
 
         params = ql.read_from_report(results, 1, -1)
         for key in results.keys():

--- a/test/qlsev2_test.py
+++ b/test/qlsev2_test.py
@@ -1,0 +1,75 @@
+import unittest
+from quasielasticbayes.v2.functions.qse_function import QSEFunction
+from quasielasticbayes.v2.functions.BG import LinearBG
+from quasielasticbayes.v2.QSE import qse_data_main
+import numpy as np
+import os.path
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
+
+
+"""
+Paramater result are from Mantid v6.5 on Windows
+"""
+
+
+class QSEV2Test(unittest.TestCase):
+    def test_one(self):
+        sx, sy, se = np.load(os.path.join(DATA_DIR, 'sample_data_red.npy'))
+        rx, ry, re = np.load(os.path.join(DATA_DIR, 'qse_res.npy'),
+                             allow_pickle=True)
+
+        sample = {'x': sx, 'y': sy, 'e': se}
+        resolution = {'x': rx, 'y': ry}
+        results = {}
+
+        results, new_x = qse_data_main(sample, resolution,
+                                       "linear", -0.4, 0.4, True, results)
+
+        # not from Mantid
+        self.assertAlmostEqual(results['N1:loglikelihood'][0], -389.94, 2)
+
+        # from Mantid, if not then as a comment
+        self.assertAlmostEqual(results['N1:f2.f2.FWHM'][0], 0.056, 3)
+        self.assertAlmostEqual(results['N1:f2.f2.beta'][0], 0.794, 3)  # 0.752
+
+        # dont compare amp to Mantid due to different scaling etc.
+        self.assertAlmostEqual(results['N1:f2.f2.Amplitude'][0], 0.167, 2)
+
+    def test_two(self):
+        """
+        Want to check that two calls to the function will append the results
+        correctly. So if we use the same input data as above, we expect
+        both values to be the same for every item in the dict.
+        """
+        sx, sy, se = np.load(os.path.join(DATA_DIR, 'sample_data_red.npy'))
+        rx, ry, re = np.load(os.path.join(DATA_DIR, 'qse_res.npy'),
+                             allow_pickle=True)
+
+        sample = {'x': sx, 'y': sy, 'e': se}
+        resolution = {'x': rx, 'y': ry}
+        results = {}
+
+        results, new_x = qse_data_main(sample, resolution,
+                                       "linear", -0.4, 0.4,
+                                       True, results)
+
+        # use the previous results to make it faster
+        lbg = LinearBG()
+        qse = QSEFunction(lbg, True, rx, ry, -.4, 0.4)
+        qse.add_single_SE()
+        params = qse.read_from_report(results, 1, 0)
+
+        # call it again
+        results, new_x = qse_data_main(sample, resolution,
+                                       "linear", -0.4, 0.4,
+                                       True, results, params)
+
+        for key in results.keys():
+            self.assertEqual(len(results[key]), 2)
+            tmp = results[key]
+            self.assertAlmostEqual(tmp[0], tmp[1], 3)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/qlsev2_test.py
+++ b/test/qlsev2_test.py
@@ -30,7 +30,7 @@ class QSEV2Test(unittest.TestCase):
         self.assertAlmostEqual(results['N1:loglikelihood'][0], -389.94, 2)
 
         # from Mantid, if not then as a comment
-        self.assertAlmostEqual(results['N1:f2.f2.FWHM'][0], 0.056, 3)
+        self.assertAlmostEqual(results['N1:f2.f2.FWHM'][0], 0.055, 3)
         self.assertAlmostEqual(results['N1:f2.f2.beta'][0], 0.794, 3)  # 0.752
 
         # dont compare amp to Mantid due to different scaling etc.


### PR DESCRIPTION
This PR makes some changes to allow easier integration into Mantid.

1. QlData can now take a starting guess
2. The FWHM calculation for SE has been corrected (see below)
3. Can now update resolution values (via interpolation)

The FWHM calculation is from equation 7 in https://neutrons.ornl.gov/sites/default/files/N8_BASIS_jp808102k.pdf converting the values for D we get 10^22 A ps, which will always cause the second term to be negligible (tau ~ 10, Q ~ 1). So the equation reduces to

FWHM = 2 hbar/ tau

You can also get this result in a hand wave way (have to assume beta approx 1) by comparing the FT of a lorentzian with the SE equation and equating 

k = t/h

to get

FWHM = 2 hbar t^(beta -1)/tau^beta 
so if beta ~ 1
FWHM =  2 hbar/tau

The last point to note is that the values for the FWHM are different when compared to Fortran. However, analysing the same data with ql data (python) using a single Lorentzian gives good agreement. Suggesting that Fortran is under estimating the FWHM. 

black = Fortran SE FWHM, 
blue = 2 hbar/tau = FWHM (python) SE, 
red = FWHM for 1 Lorentzian 
![image](https://user-images.githubusercontent.com/25006392/204572315-92b7bdec-87b9-4e9b-81b5-0409864021a2.png)

Fixes #40

Will add the above details as part of the documentation 