### PR TITLE
fix release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Build and upload to PyPI
 
 on:
-  pull_request:
   release:
     types:
         - published

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Build and upload to PyPI
 
 on:
+  pull_request:
   release:
     types:
         - published

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from fortran_setup import get_fortran_extensions, FortranExtensionBuilder
 from v2_setup import get_v2_extensions
 
 
-VERSION = "1.0.0a15"
+VERSION = "1.0.0a16"
 PACKAGE_NAME = 'quasielasticbayes'
 
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ class build_py(_build_py):
 
 setup(
     name=PACKAGE_NAME,
-    install_requires=['numpy>=1.12', 'scipy'],
+    install_requires=['numpy>=1.12', 'scipy', 'gofit'],
     packages=[PACKAGE_NAME],
     description='A Bayesian fitting package used for '
                 'fitting quasi-elastic neutron scattering data.',


### PR DESCRIPTION
The release pipeline was not working because we needed to include gofit in the setup.py. 

To test check that the new package (15) is available https://pypi.org/project/quasielasticbayes/#history (no need to install it) 