### PR TITLE
Adding quest replacement 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Build and upload to PyPI
 
 on:
-  pull_request:
   release:
     types:
         - published

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Build and upload to PyPI
 
 on:
+  pull_request:
   release:
     types:
         - published

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from fortran_setup import get_fortran_extensions, FortranExtensionBuilder
 from v2_setup import get_v2_extensions
 
 
-VERSION = "1.0.0a20"
+VERSION = "1.0.0a21"
 PACKAGE_NAME = 'quasielasticbayes'
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from fortran_setup import get_fortran_extensions, FortranExtensionBuilder
 from v2_setup import get_v2_extensions
 
 
-VERSION = "1.0.0a17"
+VERSION = "1.0.0a18"
 PACKAGE_NAME = 'quasielasticbayes'
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from fortran_setup import get_fortran_extensions, FortranExtensionBuilder
 from v2_setup import get_v2_extensions
 
 
-VERSION = "1.0.0a19"
+VERSION = "1.0.0a20"
 PACKAGE_NAME = 'quasielasticbayes'
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from fortran_setup import get_fortran_extensions, FortranExtensionBuilder
 from v2_setup import get_v2_extensions
 
 
-VERSION = "1.0.0a16"
+VERSION = "1.0.0a17"
 PACKAGE_NAME = 'quasielasticbayes'
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from fortran_setup import get_fortran_extensions, FortranExtensionBuilder
 from v2_setup import get_v2_extensions
 
 
-VERSION = "1.0.0a18"
+VERSION = "1.0.0a19"
 PACKAGE_NAME = 'quasielasticbayes'
 
 

--- a/src/quasielasticbayes/v2_python/fit_functions/qse_fixed.py
+++ b/src/quasielasticbayes/v2_python/fit_functions/qse_fixed.py
@@ -1,0 +1,88 @@
+from quasielasticbayes.v2.functions.SE_fix import StretchExpWithFixes
+from quasielasticbayes.v2.functions.base import BaseFitFunction
+from quasielasticbayes.v2.functions.qse_function import QSEFunction
+from numpy import ndarray
+from typing import List
+
+
+class QSEFixFunction(QSEFunction):
+
+    def __init__(self, bg_function: BaseFitFunction, elastic_peak: bool,
+                 r_x: ndarray, r_y: ndarray, start_x: float, end_x: float):
+        """
+        Create a quasi elastic fitting function using fixed stretched exp
+        :param bg_function: background fitting function
+        :param elastic_peak: if to include an elastic peak (True/False)
+        :param res_x: x values for resolution function
+        :param res_y: y values for resolution function
+        :param start_x: the start of the fitting range
+        :param end_x: the end of the fitting range
+        """
+        self._se = []
+        super().__init__(bg_function, elastic_peak, r_x,
+                         r_y, start_x, end_x)
+
+    def add_single_SE(self) -> None:
+        """
+        adds a single stretched exp with fixes
+        """
+        self._se.append(StretchExpWithFixes())
+        self.add_single_function(self._se[-1])
+
+    def _get_func_from_report(self, args: List[float]) -> List[float]:
+        # skip the peak centre
+        return [args[0]]
+
+    def _func_guess(self, full_guess: List[float]) -> List[float]:
+        """
+        Get the intial guess values.
+        This takes into account the tied
+        parameters.
+        :return a list of guess parameters for the fit
+        """
+        # skip peak centre
+        return [full_guess[0]]
+
+    def set_beta(self, beta: float, index: int = -1) -> None:
+        """
+        sets the beta value for the fix
+        :param beta: the beta value to fix to
+        """
+        if self._se == []:
+            return
+        self._se[index].set_beta(beta)
+
+    def set_FWHM(self, FWHM, index: int = -1) -> None:
+        """
+        sets the FWHM value for the fix
+        :param FWHM: the FWHM value to fix to
+        """
+        if self._se == []:
+            return
+        self._se[index].set_FWHM(FWHM)
+
+    def _add_params(self, offset: int, x0: float,
+                    args: List[float]) -> List[float]:
+        """
+        Gets the amplitude and peak centre
+        :param offset: the offset in the index
+        :param x0: the peak centre
+        :param args: the arguments
+        :return a list of parameters for the SE
+        """
+        # adds amplitude, peak centre
+        return [args[offset], x0]
+
+    def set_func_guess_FWHM(self, guess: List[float], index=-1) -> None:
+        """
+        Set the  guess values.
+        :param guess: the guess for the function, assume
+        FWHM is in index 2
+        :param index: the index of the function
+        """
+        if self.N_peaks == 0:
+            return
+
+        self.set_FWHM(guess[2], index)
+
+        super().set_func_guess(guess[0:2], index)

--- a/src/quasielasticbayes/v2_python/fit_functions/qse_fixed.py
+++ b/src/quasielasticbayes/v2_python/fit_functions/qse_fixed.py
@@ -29,7 +29,8 @@ class QSEFixFunction(QSEFunction):
         self._se.append(StretchExpWithFixes())
         self.add_single_function(self._se[-1])
 
-    def _get_func_from_report(self, args: List[float]) -> List[float]:
+    @staticmethod
+    def _get_func_from_report(args: List[float]) -> List[float]:
         """
         extracts the relevant info from report (excluding fixes)
         :param args: the full list of arguments.
@@ -37,7 +38,8 @@ class QSEFixFunction(QSEFunction):
         """
         return [args[0]]
 
-    def _func_guess(self, full_guess: List[float]) -> List[float]:
+    @staticmethod
+    def _func_guess(full_guess: List[float]) -> List[float]:
         """
         Get the intial guess values.
         This takes into account the tied
@@ -51,8 +53,9 @@ class QSEFixFunction(QSEFunction):
         """
         sets the beta value for the fix
         :param beta: the beta value to fix to
+        :param index: the index of the se
         """
-        if self._se == []:
+        if not self._se:
             return
         self._se[index].set_beta(beta)
 
@@ -60,6 +63,7 @@ class QSEFixFunction(QSEFunction):
         """
         sets the FWHM value for the fix
         :param FWHM: the FWHM value to fix to
+        :param index: the index of the se
         """
         if self._se == []:
             return

--- a/src/quasielasticbayes/v2_python/fit_functions/qse_fixed.py
+++ b/src/quasielasticbayes/v2_python/fit_functions/qse_fixed.py
@@ -41,7 +41,7 @@ class QSEFixFunction(QSEFunction):
     @staticmethod
     def _func_guess(full_guess: List[float]) -> List[float]:
         """
-        Get the intial guess values.
+        Get the initial guess values.
         This takes into account the tied
         parameters.
         :return a list of guess parameters for the fit

--- a/src/quasielasticbayes/v2_python/fit_functions/qse_fixed.py
+++ b/src/quasielasticbayes/v2_python/fit_functions/qse_fixed.py
@@ -65,11 +65,12 @@ class QSEFixFunction(QSEFunction):
         :param FWHM: the FWHM value to fix to
         :param index: the index of the se
         """
-        if self._se == []:
+        if not self._se:
             return
         self._se[index].set_FWHM(FWHM)
 
-    def _add_params(self, offset: int, x0: float,
+    @staticmethod
+    def _add_params(offset: int, x0: float,
                     args: List[float]) -> List[float]:
         """
         Gets the amplitude and peak centre

--- a/src/quasielasticbayes/v2_python/fit_functions/qse_fixed.py
+++ b/src/quasielasticbayes/v2_python/fit_functions/qse_fixed.py
@@ -30,7 +30,11 @@ class QSEFixFunction(QSEFunction):
         self.add_single_function(self._se[-1])
 
     def _get_func_from_report(self, args: List[float]) -> List[float]:
-        # skip the peak centre
+        """
+        extracts the relevant info from report (excluding fixes)
+        :param args: the full list of arguments.
+        :return the arguments, skipping the peak centre
+        """
         return [args[0]]
 
     def _func_guess(self, full_guess: List[float]) -> List[float]:

--- a/src/quasielasticbayes/v2_python/fit_functions/stretch_exp_fixed.py
+++ b/src/quasielasticbayes/v2_python/fit_functions/stretch_exp_fixed.py
@@ -6,7 +6,7 @@ from typing import Dict, List
 class StretchExpWithFixes(StretchExp):
     def __init__(self, FWHM: float = 0.2, beta: float = 0.8, prefix: str = ''):
         """
-        Create a stretched exponenetial function with 2 fixed parameters.
+        Create a stretched exponential function with 2 fixed parameters.
         :param FWHM: full width half max value for the fix
         :param beta: the beta value for the fix
         :param prefix: the prefix for the parameters
@@ -82,7 +82,7 @@ class StretchExpWithFixes(StretchExp):
 
     def set_guess_FWHM(self, value: List[float]) -> None:
         """
-        This is an inheritred function that will not do anything
+        This is an inherited function that will not do anything
         :param value: value to set
         """
         raise RuntimeError("this method does not work with fix")

--- a/src/quasielasticbayes/v2_python/fit_functions/stretch_exp_fixed.py
+++ b/src/quasielasticbayes/v2_python/fit_functions/stretch_exp_fixed.py
@@ -102,7 +102,7 @@ class StretchExpWithFixes(StretchExp):
         :return update results dict
         """
         return super().report(report_dict, a, x0,
-                                 self.get_tau, self.get_beta)
+                              self.get_tau, self.get_beta)
 
     def report_errors(self, report_dict: Dict[str, List[float]],
                       errors: ndarray,

--- a/src/quasielasticbayes/v2_python/fit_functions/stretch_exp_fixed.py
+++ b/src/quasielasticbayes/v2_python/fit_functions/stretch_exp_fixed.py
@@ -7,11 +7,6 @@ class StretchExpWithFixes(StretchExp):
     def __init__(self, FWHM: float = 0.2, beta: float = 0.8, prefix: str = ''):
         """
         Create a stretched exponenetial function with 2 fixed parameters.
-        This inherits base fit function and not the strectched exp,
-        because we want to set the number of parameters to 2.
-        Otherwise we will need to complicate the code to handle
-        the fixed parameters. Instead we create an
-        instance of the StretchExp function
         :param FWHM: full width half max value for the fix
         :param beta: the beta value for the fix
         :param prefix: the prefix for the parameters
@@ -26,14 +21,14 @@ class StretchExpWithFixes(StretchExp):
         self._lower = self._lower[0:2]
         self._upper = self._upper[0:2]
 
-    def set_FWHM(self, FWHM: float):
+    def set_FWHM(self, FWHM: float) -> None:
         """
         Update the FWHM fix value
         :param FWHM: full width half max for fix
         """
         self._tau = self.tau(FWHM)
 
-    def set_beta(self, beta: float):
+    def set_beta(self, beta: float) -> None:
         """
         Update the beta fix value
         :param beta: the beta value for fix
@@ -41,15 +36,16 @@ class StretchExpWithFixes(StretchExp):
         self._beta = beta
 
     @property
-    def get_tau(self):
+    def get_tau(self) -> float:
         """
-        Get the tau value being used
+        Get the tau value being used.
+        tau is related to the FWHM.
         :return the tau value used in fix
         """
         return self._tau
 
     @property
-    def get_beta(self):
+    def get_beta(self) -> float:
         """
         Gets the beta value being used
         :return beta value for fix
@@ -67,7 +63,6 @@ class StretchExpWithFixes(StretchExp):
         :param x0: the peak centre
         :return y values for function evaluation
         """
-
         return super().__call__(x, amplitude, x0, self.get_tau, self.get_beta)
 
     def read_from_report(self, report_dict: Dict[str, List[float]],
@@ -80,7 +75,6 @@ class StretchExpWithFixes(StretchExp):
         :return the parameters
         """
         self._tau = self._read_report(report_dict, self.tau_str, index)
-
         self.set_beta(self._read_report(report_dict, self.beta, index))
 
         return [self._read_report(report_dict, self.amplitude, index),
@@ -88,9 +82,10 @@ class StretchExpWithFixes(StretchExp):
 
     def set_guess_FWHM(self, value: List[float]) -> None:
         """
-        This is an inheritred function that will not work
+        This is an inheritred function that will not do anything
+        :param value: value to set
         """
-        return
+        raise RuntimeError("this method does not work with fix")
 
     def report(self, report_dict: Dict[str, List[float]],
                a: float, x0: float) -> Dict[str, List[float]]:

--- a/src/quasielasticbayes/v2_python/test_helpers/workflow_helper.py
+++ b/src/quasielasticbayes/v2_python/test_helpers/workflow_helper.py
@@ -1,0 +1,76 @@
+from quasielasticbayes.v2.functions.BG import LinearBG
+from quasielasticbayes.v2.functions.composite import CompositeFunction
+import numpy as np
+
+
+"""
+Helper functions and classes
+for testing workflows
+"""
+
+"""
+data generation
+"""
+
+
+def gen_model_selection_data():
+    x = np.linspace(1, 4, 100)
+    np.random.seed(1)
+    noise_stdev = 0.1
+    y = np.random.normal(0.5 +
+                         1.2*np.exp(-2*x), noise_stdev)
+    e = 0.5*noise_stdev*np.ones(x.shape)
+    return x, y, e
+
+
+def gen_grid_search_data():
+    x = np.linspace(1, 4, 100)
+    np.random.seed(1)
+    noise_stdev = 0.1
+    y = np.random.normal(0.5 + 0.2*x +
+                         1.2*np.exp(-2*x), noise_stdev)
+    e = 0.5*noise_stdev*np.ones(x.shape)
+    return x, y, e
+
+
+"""
+Fitting function, need some defintions
+of fitting functions with fixes for
+testing grid search.
+These are minimal fitting functions
+so that the tests can pass. Some
+methods/functionality is missing.
+"""
+
+
+class FixedBG(LinearBG):
+    def __init__(self, prefix=''):
+        super().__init__(prefix)
+        self._N_params = 0
+        self._guess = []
+        self._lower = []
+        self._upper = []
+        self._c = 0
+        self._m = 0
+
+    def set_c(self, val):
+        self._c = val
+
+    def set_m(self, val):
+        self._m = val
+
+    def report(self, result):
+        return super().report(result, self._m, self._c)
+
+    def __call__(self, x):
+        return super().__call__(x, self._m, self._c)
+
+
+class FixedComposite(CompositeFunction):
+    def set_c(self, val):
+        # assume first entry is always fixed func
+        self._funcs[0].set_c(val)
+
+    def set_m(self, val):
+        # assume first entry is always fixed func
+        self._funcs[0].set_m(val)

--- a/src/quasielasticbayes/v2_python/test_helpers/workflow_helper.py
+++ b/src/quasielasticbayes/v2_python/test_helpers/workflow_helper.py
@@ -34,7 +34,7 @@ def gen_grid_search_data():
 
 
 """
-Fitting function, need some defintions
+Fitting function, need some definitions
 of fitting functions with fixes for
 testing grid search.
 These are minimal fitting functions

--- a/src/quasielasticbayes/v2_python/workflows/grid_search/grid_search_template.py
+++ b/src/quasielasticbayes/v2_python/workflows/grid_search/grid_search_template.py
@@ -1,59 +1,138 @@
 from quasielasticbayes.v2.workflow.template import WorkflowTemplate
 from quasielasticbayes.v2.log_likelihood import loglikelihood
+from quasielasticbayes.v2.functions.base import BaseFitFunction
 
 from numpy import ndarray
 import numpy as np
-from typing import Dict
 from abc import abstractmethod
 
 
 class Axis(object):
+    """
+    A simple object for holding the information
+    about an axis
+    """
     def __init__(self, start, end, N, label='x'):
+        """
+        Create an axis
+        :param start: the first value for the axis
+        :param end: the last value for the axis
+        :param N: the number of values along the axis
+        :param label: the name of the axis
+        """
         self._len = N
         self._label = label
         self._vals = np.linspace(start, end, N)
 
     @property
-    def label(self):
+    def label(self) -> str:
+        """
+        Get the label for the axis
+        :return the label
+        """
         return self._label
 
     @property
     def len(self):
+        """
+        Get the length of the axis
+        :return the length of the axis
+        """
         return self._len
 
     @property
     def values(self):
+        """
+        Get the values used on the axis
+        :return the values from the axis
+        """
         return self._vals
 
 
 class GridSearchTemplate(WorkflowTemplate):
-    def __init__(self, results: Dict[str, ndarray],
-                 results_errors: Dict[str, ndarray]):
+    """
+    A workflow for a grid search.
+    A grid search will do a series of fits for a range of
+    x and y values, that correspond to fixed parameters in
+    the fitting function.
+
+    The inherited class must include:
+    - _set_x_value
+    - _set_y_value
+    - N
+
+    The properties are:
+    - fit_engine
+    - get_grid
+    - get_x_axis
+    - get_y_axis
+
+    To add a fit engine:
+    - set_scipy_engine (scipy curve fit, recomended)
+    - set_gofit_engine (gofit)
+
+    Other methods:
+    - preprocess_data
+    - update_fit_engine
+    - update_function (call this one not the overwritten one)
+    - execute
+    - set_x_axis
+    - set_y_axis
+    - N
+    """
+    def __init__(self):
         """
         Set the results and error dicts for reporting
-        :param results: dict of parameter values
-        :param results_errors: dict of parameter errors
         """
-        super().__init__(results, results_errors)
+        super().__init__()
         self._x_axis = None
         self._y_axis = None
         self._grid = None
 
-    def set_x_axis(self, start, end, N, label):
+    def set_x_axis(self, start: float, end: float,
+                   N: int, label: str) -> None:
+        """
+        Sets the x axis for the workflow
+        :param start: the first value on the x axis
+        :param end: the last value on the x axis
+        :param N: the number of values on the x axis
+        :param label: the x axis label
+        """
         self._x_axis = Axis(start, end, N, label)
 
     @property
-    def get_x_axis(self):
+    def get_x_axis(self) -> Axis:
+        """
+        Get the x axis
+        :return the x axis object
+        """
         return self._x_axis
 
-    def set_y_axis(self, start, end, N, label):
+    def set_y_axis(self, start: float, end: float,
+                   N: int, label: str) -> None:
+        """
+        Sets the y axis for the workflow
+        :param start: the first value on the y axis
+        :param end: the last value on the y axis
+        :param N: the number of values on the y axis
+        :param label: the y axis label
+        """
         self._y_axis = Axis(start, end, N, label)
 
     @property
-    def get_y_axis(self):
+    def get_y_axis(self) -> Axis:
+        """
+        Get the y axis
+        :return the y axis object
+        """
         return self._y_axis
 
-    def generate_mesh(self):
+    def _generate_grid(self) -> (ndarray, ndarray):
+        """
+        Creates a grid from the axis.
+        Need to have set the x and y axis first.
+        :return the X and Y values from np.meshgrid
+        """
         if self._x_axis is None or self._y_axis is None:
             raise ValueError("The x and/or y axis has"
                              " not been set. Please use "
@@ -61,48 +140,94 @@ class GridSearchTemplate(WorkflowTemplate):
 
         X, Y = np.meshgrid(self._x_axis.values,
                            self._y_axis.values)
-        self._grid = self.empty_mesh(X, Y)
+        self._grid = self._empty_mesh(X, Y)
         return X, Y
 
     @staticmethod
-    def empty_mesh(X, Y):
-        z = X + Y
-        return np.zeros(z.shape)
+    def _empty_mesh(X: ndarray, Y: ndarray) -> None:
+        """
+        Creates a grid of the correct size with zeros
+        :param X: one the meshgrid outputs
+        """
+        return np.zeros(X.shape)
 
     @property
-    def get_grid(self):
+    def get_grid(self) -> ndarray:
+        """
+        Get the grid values
+        :return the grid values
+        """
         return self._grid
 
-    def get_slices(self):
+    def get_slices(self) -> (ndarray, ndarray):
+        """
+        Gets slices along the x and y axis, such that
+        the peak grid value is in both slices.
+        :return the x and y data slices
+        """
         indicies = np.where(self._grid == self._grid.max())
         x_slice = self._grid[indicies[0], :][0]
         y_slice = [vec[0] for vec in self._grid[:, indicies[1]]]
-        return x_slice, y_slice
+        return x_slice, np.array(y_slice)
 
     @abstractmethod
-    def set_x_value(self, func, value):
+    def _set_x_value(self, func: BaseFitFunction,
+                     value: float) -> BaseFitFunction:
+        """
+        Sets the x value (fixed fit parameter)
+        :param func: the function that is being updated
+        :param value: the fix value
+        """
         raise NotImplementedError()
 
     @abstractmethod
-    def set_y_value(self, func, value):
+    def _set_y_value(self, func: BaseFitFunction,
+                     value: float) -> BaseFitFunction:
+        """
+        Sets the y value (fixed fit parameter)
+        :param func: the function that is being updated
+        :param value: the fix value
+        """
         raise NotImplementedError()
 
-    def get_z_value(self, N_x, N_peaks, scale):
+    def _get_z_value(self, N_p: int, N_f: int, scale: float) -> float:
+        """
+        Gets the loglikelihood value
+        :param N_p: the number of data points being fitted to
+        :param N_f: the number of features being fitted to
+        :param scale: the beta scale factor for loglikelihood
+        :return the loglikelihood
+        """
         chi2 = self._engine.get_chi_squared()
         covar = self._engine.get_covariance_matrix()
-        return loglikelihood(N_x, chi2, covar,
-                             N_peaks, scale)
+        return loglikelihood(N_p, chi2, covar,
+                             N_f, scale)
 
-    def normalise_grid(self):
+    def _normalise_grid(self) -> None:
+        """
+        Rescales the grid values so that the max is 1
+        and the min is 0. This should make features clearer
+        """
         self._grid = np.min(self._grid)/self._grid
         self._grid -= np.min(self._grid)
         self._grid /= np.max(self._grid)
 
     @abstractmethod
-    def N(self, func):
+    def N(self, func: BaseFitFunction) -> int:
+        """
+        Gets the number of features in the fit function
+        :param func: the fitting function
+        :return the number of features
+        """
         raise NotImplementedError()
 
-    def execute(self, func, results):
+    def execute(self, func: BaseFitFunction) -> (ndarray, ndarray):
+        """
+        Does the grid search. Needs the x and y axis to be set.
+        Also needs a fitting engine to be set.
+        :param func: the fitting function
+        :return the X and Y values for the grid
+        """
         if self._engine is None:
             raise ValueError("please set a fit engine")
         x_data = self._data['x']
@@ -110,26 +235,25 @@ class GridSearchTemplate(WorkflowTemplate):
         e_data = self._data['e']
         scale = np.max(y_data)*(np.max(x_data) - np.min(x_data))
 
-        X, Y = self.generate_mesh()
+        X, Y = self._generate_grid()
 
         N = len(self.get_x_axis.values)*len(self.get_y_axis.values)
         counter = 0
 
         for i, xx in enumerate(self.get_x_axis.values):
-            func = self.set_x_value(func, xx)
+            func = self._set_x_value(func, xx)
             params = func.get_guess()
 
             for j, yy in enumerate(self.get_y_axis.values):
-                func = self.set_y_value(func, yy)
+                func = self._set_y_value(func, yy)
                 self._engine.do_fit(x_data, y_data, e_data, func)
                 params, _ = self._engine.get_fit_parameters()
 
-                results = func.report(results, *params)
                 num = self.N(func)
-                self._grid[j][i] = self.get_z_value(len(x_data),
-                                                    num,
-                                                    scale)
+                self._grid[j][i] = self._get_z_value(len(x_data),
+                                                     num,
+                                                     scale)
                 counter += 1
                 print(f'\rPercentage complete: {100*counter/N:2f}')
-        self.normalise_grid()
+        self._normalise_grid()
         return X, Y

--- a/src/quasielasticbayes/v2_python/workflows/grid_search/grid_search_template.py
+++ b/src/quasielasticbayes/v2_python/workflows/grid_search/grid_search_template.py
@@ -124,9 +124,9 @@ class GridSearchTemplate(Workflow):
 
                 results = func.report(results, *params)
                 num = self.N(func)
-                self._grid[j][i] = get_z_value(len(x_data),
-                                               num,
-                                               scale)
+                self._grid[j][i] = self.get_z_value(len(x_data),
+                                                    num,
+                                                    scale)
                 counter += 1
                 print(f'\rPercentage complete: {100*counter/N:2f}')
         self.normalise_grid()

--- a/src/quasielasticbayes/v2_python/workflows/grid_search/grid_search_template.py
+++ b/src/quasielasticbayes/v2_python/workflows/grid_search/grid_search_template.py
@@ -1,4 +1,4 @@
-from quasielasticbayes.v2.workflow.template import Workflow
+from quasielasticbayes.v2.workflow.template import WorkflowTemplate
 from quasielasticbayes.v2.log_likelihood import loglikelihood
 
 from numpy import ndarray
@@ -26,7 +26,7 @@ class Axis(object):
         return self._vals
 
 
-class GridSearchTemplate(Workflow):
+class GridSearchTemplate(WorkflowTemplate):
     def __init__(self, results: Dict[str, ndarray],
                  results_errors: Dict[str, ndarray]):
         """
@@ -39,15 +39,15 @@ class GridSearchTemplate(Workflow):
         self._y_axis = None
         self._grid = None
 
-    def set_x_axis(self, start, end, N):
-        self._x_axis = Axis(start, end, N)
+    def set_x_axis(self, start, end, N, label):
+        self._x_axis = Axis(start, end, N, label)
 
     @property
     def get_x_axis(self):
         return self._x_axis
 
-    def set_y_axis(self, start, end, N):
-        self._y_axis = Axis(start, end, N)
+    def set_y_axis(self, start, end, N, label):
+        self._y_axis = Axis(start, end, N, label)
 
     @property
     def get_y_axis(self):
@@ -55,9 +55,9 @@ class GridSearchTemplate(Workflow):
 
     def generate_mesh(self):
         if self._x_axis is None or self._y_axis is None:
-            raise RuntimeError("The x and/or y axis has"
-                               " not been set. Please use "
-                               "set_x_axis and set_y_axis.")
+            raise ValueError("The x and/or y axis has"
+                             " not been set. Please use "
+                             "set_x_axis and set_y_axis.")
 
         X, Y = np.meshgrid(self._x_axis.values,
                            self._y_axis.values)
@@ -103,6 +103,8 @@ class GridSearchTemplate(Workflow):
         raise NotImplementedError()
 
     def execute(self, func, results):
+        if self._engine is None:
+            raise ValueError("please set a fit engine")
         x_data = self._data['x']
         y_data = self._data['y']
         e_data = self._data['e']

--- a/src/quasielasticbayes/v2_python/workflows/grid_search/grid_search_template.py
+++ b/src/quasielasticbayes/v2_python/workflows/grid_search/grid_search_template.py
@@ -100,7 +100,7 @@ class GridSearchTemplate(Workflow):
         self._grid = norm
 
     @abstractmethod
-    def N(self):
+    def N(self, func):
         raise NotImplementedError()
 
     def execute(self, func, results):
@@ -124,8 +124,9 @@ class GridSearchTemplate(Workflow):
                 params, _ = self._engine.get_fit_parameters()
 
                 results = func.report(results, *params)
+                num = self.N(func)
                 self._grid[j][i] = self.get_z_value(len(x_data),
-                                                    self.N,
+                                                    num,
                                                     scale)
                 counter += 1
                 print(f'\rPercentage complete: {100*counter/N:2f}')

--- a/src/quasielasticbayes/v2_python/workflows/grid_search/grid_search_template.py
+++ b/src/quasielasticbayes/v2_python/workflows/grid_search/grid_search_template.py
@@ -68,7 +68,7 @@ class GridSearchTemplate(WorkflowTemplate):
     - get_y_axis
 
     To add a fit engine:
-    - set_scipy_engine (scipy curve fit, recomended)
+    - set_scipy_engine (scipy curve fit, recommended)
     - set_gofit_engine (gofit)
 
     Other methods:
@@ -165,9 +165,9 @@ class GridSearchTemplate(WorkflowTemplate):
         the peak grid value is in both slices.
         :return the x and y data slices
         """
-        indicies = np.where(self._grid == self._grid.max())
-        x_slice = self._grid[indicies[0], :][0]
-        y_slice = [vec[0] for vec in self._grid[:, indicies[1]]]
+        indices = np.where(self._grid == self._grid.max())
+        x_slice = self._grid[indices[0], :][0]
+        y_slice = [vec[0] for vec in self._grid[:, inidces[1]]]
         return x_slice, np.array(y_slice)
 
     @abstractmethod

--- a/src/quasielasticbayes/v2_python/workflows/grid_search/grid_search_template.py
+++ b/src/quasielasticbayes/v2_python/workflows/grid_search/grid_search_template.py
@@ -123,7 +123,7 @@ class GridSearchTemplate(Workflow):
                 self._engine.do_fit(x_data, y_data, e_data, func)
                 params, _ = self._engine.get_fit_parameters()
 
-                results = func.report(results, params)
+                results = func.report(results, *params)
                 self._grid[j][i] = self.get_z_value(len(x_data),
                                                     self.N,
                                                     scale)

--- a/src/quasielasticbayes/v2_python/workflows/grid_search/grid_search_template.py
+++ b/src/quasielasticbayes/v2_python/workflows/grid_search/grid_search_template.py
@@ -140,14 +140,14 @@ class GridSearchTemplate(WorkflowTemplate):
 
         X, Y = np.meshgrid(self._x_axis.values,
                            self._y_axis.values)
-        self._grid = self._empty_mesh(X, Y)
+        self._grid = self._empty_mesh(X)
         return X, Y
 
     @staticmethod
-    def _empty_mesh(X: ndarray, Y: ndarray) -> None:
+    def _empty_mesh(X: ndarray) -> None:
         """
         Creates a grid of the correct size with zeros
-        :param X: one the meshgrid outputs
+        :param X: one of the meshgrid outputs
         """
         return np.zeros(X.shape)
 

--- a/src/quasielasticbayes/v2_python/workflows/grid_search/grid_search_template.py
+++ b/src/quasielasticbayes/v2_python/workflows/grid_search/grid_search_template.py
@@ -1,0 +1,132 @@
+from quasielasticbayes.v2.workflow.template import Workflow
+from quasielasticbayes.v2.log_likelihood import loglikelihood
+
+from numpy import ndarray
+import numpy as np
+from typing import Dict
+from abc import abstractmethod
+
+
+class Axis(object):
+    def __init__(self, start, end, N, label='x'):
+        self._len = N
+        self._label = label
+        self._vals = np.linspace(start, end, N)
+
+    @property
+    def label(self):
+        return self._label
+
+    @property
+    def len(self):
+        return self._len
+
+    @property
+    def values(self):
+        return self._vals
+
+
+class GridSearchTemplate(Workflow):
+    def __init__(self, results: Dict[str, ndarray],
+                 results_errors: Dict[str, ndarray]):
+        """
+        Set the results and error dicts for reporting
+        :param results: dict of parameter values
+        :param results_errors: dict of parameter errors
+        """
+        super().__init__(results, results_errors)
+        self._x_axis = None
+        self._y_axis = None
+        self._grid = None
+
+    def set_x_axis(self, start, end, N):
+        self._x_axis = Axis(start, end, N)
+
+    @property
+    def get_x_axis(self):
+        return self._x_axis
+
+    def set_y_axis(self, start, end, N):
+        self._y_axis = Axis(start, end, N)
+
+    @property
+    def get_y_axis(self):
+        return self._y_axis
+
+    def generate_mesh(self):
+        if self._x_axis is None or self._y_axis is None:
+            raise RuntimeError("The x and/or y axis has"
+                               " not been set. Please use "
+                               "set_x_axis and set_y_axis.")
+
+        X, Y = np.meshgrid(self._x_axis.values,
+                           self._y_axis.values)
+        self._grid = self.empty_mesh(X, Y)
+        return X, Y
+
+    @staticmethod
+    def empty_mesh(X, Y):
+        z = X + Y
+        return np.zeros(z.shape)
+
+    @property
+    def get_grid(self):
+        return self._grid
+
+    def get_slices(self):
+        indicies = np.where(self._grid == self._grid.max())
+        x_slice = self._grid[indicies[0], :]
+        y_slice = self._grid[:, indicies[1]]
+        return x_slice, y_slice
+
+    @abstractmethod
+    def set_x_value(self, func, value):
+        raise NotImplementedError()
+
+    @abstractmethod
+    def set_y_value(self, func, value):
+        raise NotImplementedError()
+
+    def get_z_value(self, N_x, N_peaks, scale):
+        chi2 = self._engine.get_chi_squared()
+        covar = self._engine.get_covariance_matrix()
+        return loglikelihood(N_x, chi2, covar,
+                             N_peaks, scale)
+
+    def normalise_grid(self):
+        norm = np.min(self._grid)/self._grid
+        norm -= np.min(self._grid)
+        norm /= np.max(self._grid)
+        self._grid = norm
+
+    @abstractmethod
+    def N(self):
+        raise NotImplementedError()
+
+    def execute(self, func, results):
+        x_data = self._data['x']
+        y_data = self._data['y']
+        e_data = self._data['e']
+        scale = np.max(y_data)*(np.max(x_data) - np.min(x_data))
+
+        self.generate_mesh()
+
+        N = len(self.get_x_axis.values)*len(self.get_y_axis.values)
+        counter = 0
+
+        for i, xx in enumerate(self.get_x_axis.values):
+            func = self.set_x_value(func, xx)
+            params = func.get_guess()
+
+            for j, yy in enumerate(self.get_y_axis.values):
+                func = self.set_y_value(func, yy)
+                self._engine.do_fit(x_data, y_data, e_data, func)
+                params, _ = self._engine.get_fit_parameters()
+
+                results = func.report(results, params)
+                self._grid[j][i] = self.get_z_value(len(x_data),
+                                                    self.N,
+                                                    scale)
+                counter += 1
+                print(f'\rPercentage complete: {100*counter/N:2f}')
+        self.normalise_grid()

--- a/src/quasielasticbayes/v2_python/workflows/grid_search/grid_search_template.py
+++ b/src/quasielasticbayes/v2_python/workflows/grid_search/grid_search_template.py
@@ -167,7 +167,7 @@ class GridSearchTemplate(WorkflowTemplate):
         """
         indices = np.where(self._grid == self._grid.max())
         x_slice = self._grid[indices[0], :][0]
-        y_slice = [vec[0] for vec in self._grid[:, inidces[1]]]
+        y_slice = [vec[0] for vec in self._grid[:, indices[1]]]
         return x_slice, np.array(y_slice)
 
     @abstractmethod

--- a/src/quasielasticbayes/v2_python/workflows/grid_search/qse_grid_search.py
+++ b/src/quasielasticbayes/v2_python/workflows/grid_search/qse_grid_search.py
@@ -2,6 +2,7 @@ from quasielasticbayes.v2.workflow.grid_template import GridSearchTemplate
 from quasielasticbayes.v2.functions.qse_fixed import QSEFixFunction
 from quasielasticbayes.v2.utils.spline import spline
 from numpy import ndarray
+from typing import Dict
 import numpy as np
 
 

--- a/src/quasielasticbayes/v2_python/workflows/grid_search/qse_grid_search.py
+++ b/src/quasielasticbayes/v2_python/workflows/grid_search/qse_grid_search.py
@@ -1,0 +1,49 @@
+from quasielasticbayes.v2.workflow.grid_search import GridSearchTemplate
+# from quasielasticbayes.v2.functions.qse_fixed import QSEFunction
+from quasielasticbayes.v2.utils.spline import spline
+from numpy import ndarray
+import numpy as np
+from typing import Dict
+
+
+class QSEGridSearch(GridSearchTemplate):
+
+    def preprocess_data(self, x_data: ndarray,
+                        y_data: ndarray, e_data: ndarray,
+                        start_x: float, end_x: float,
+                        res: Dict[str, ndarray]) -> (ndarray, ndarray):
+        """
+        The preprocessing needed for the data.
+        It splines the sample and resolution data
+        to the same uniform grid.
+        :param x_data: the sample x data to fit to
+        :param y_data: the sample y data to fit to
+        :param e_data: the sample errors for the y data
+        :param start_x: the start x value
+        :param end_x: the end x value
+        :param res: a dict of the resolution data (keys =x, y, e)
+        :return the new x range and the new resolution y values
+        """
+        dx = x_data[1] - x_data[0]
+        new_x = np.linspace(start_x, end_x, int((end_x - start_x)/dx))
+
+        sy = spline(x_data, y_data, new_x)
+        se = spline(x_data, e_data, new_x)
+        ry = spline(res['x'], res['y'], new_x)
+        super().preprocess_data(new_x, sy, se)
+
+        return new_x, ry
+
+    @staticmethod
+    def set_x_value(self, func, value):
+        func.set_beta(value)
+        return func
+
+    @staticmethod
+    def set_y_value(self, func, value):
+        func.set_FWHM(value)
+        return func
+
+    @staticmethod
+    def N(self):
+        return 1

--- a/src/quasielasticbayes/v2_python/workflows/grid_search/qse_grid_search.py
+++ b/src/quasielasticbayes/v2_python/workflows/grid_search/qse_grid_search.py
@@ -1,13 +1,35 @@
 from quasielasticbayes.v2.workflow.grid_template import GridSearchTemplate
-# from quasielasticbayes.v2.functions.qse_fixed import QSEFunction
+from quasielasticbayes.v2.functions.qse_fixed import QSEFixFunction
 from quasielasticbayes.v2.utils.spline import spline
 from numpy import ndarray
 import numpy as np
-from typing import Dict
 
 
 class QSEGridSearch(GridSearchTemplate):
+    """
+    A workflow for doing a grid search of quasielastic
+    data to fit a stretch exponential for different
+    (fixed) beta and FWHM values.
 
+    The properties are:
+    - fit_engine
+    - get_grid
+    - get_x_axis
+    - get_y_axis
+    - N
+
+    To add a fit engine:
+    - set_scipy_engine (scipy curve fit, recomended)
+    - set_gofit_engine (gofit)
+
+    Other methods:
+    - preprocess_data
+    - update_fit_engine
+    - update_function (call this one not the overwritten one)
+    - execute
+    - set_x_axis
+    - set_y_axis
+    """
     def preprocess_data(self, x_data: ndarray,
                         y_data: ndarray, e_data: ndarray,
                         start_x: float, end_x: float,
@@ -16,6 +38,7 @@ class QSEGridSearch(GridSearchTemplate):
         The preprocessing needed for the data.
         It splines the sample and resolution data
         to the same uniform grid.
+        This is designed for a fixed stretched exp.
         :param x_data: the sample x data to fit to
         :param y_data: the sample y data to fit to
         :param e_data: the sample errors for the y data
@@ -35,15 +58,36 @@ class QSEGridSearch(GridSearchTemplate):
         return new_x, ry
 
     @staticmethod
-    def set_x_value(func, value):
+    def _set_x_value(func: QSEFixFunction,
+                     value: float) -> QSEFixFunction:
+        """
+        Sets the beta value for the fit
+        function (x axis)
+        :param func: the stretch exp with fixes function
+        :param value: the value to fix beta to
+        :return the updated fit function
+        """
         func.set_beta(value)
         return func
 
     @staticmethod
-    def set_y_value(func, value):
+    def _set_y_value(func: QSEFixFunction,
+                     value: float) -> QSEFixFunction:
+        """
+        Sets the FWHM (tau) value for the fit
+        function (y axis)
+        :param func: the stretch exp with fixes function
+        :param value: the value to fix FWHM (tau) to
+        :return the updated fit function
+        """
         func.set_FWHM(value)
         return func
 
     @staticmethod
-    def N(func):
-        return 1
+    def N(func: QSEFixFunction) -> int:
+        """
+        Get the number of features from fit
+        :param func: the fitting function
+        :return the number of features
+        """
+        return func._N_peaks

--- a/src/quasielasticbayes/v2_python/workflows/grid_search/qse_grid_search.py
+++ b/src/quasielasticbayes/v2_python/workflows/grid_search/qse_grid_search.py
@@ -20,7 +20,7 @@ class QSEGridSearch(GridSearchTemplate):
     - N
 
     To add a fit engine:
-    - set_scipy_engine (scipy curve fit, recomended)
+    - set_scipy_engine (scipy curve fit, recommended)
     - set_gofit_engine (gofit)
 
     Other methods:
@@ -91,4 +91,4 @@ class QSEGridSearch(GridSearchTemplate):
         :param func: the fitting function
         :return the number of features
         """
-        return func._N_peaks
+        return func.N_peaks()

--- a/src/quasielasticbayes/v2_python/workflows/grid_search/qse_grid_search.py
+++ b/src/quasielasticbayes/v2_python/workflows/grid_search/qse_grid_search.py
@@ -45,5 +45,5 @@ class QSEGridSearch(GridSearchTemplate):
         return func
 
     @staticmethod
-    def N():
+    def N(func):
         return 1

--- a/src/quasielasticbayes/v2_python/workflows/grid_search/qse_grid_search.py
+++ b/src/quasielasticbayes/v2_python/workflows/grid_search/qse_grid_search.py
@@ -35,15 +35,15 @@ class QSEGridSearch(GridSearchTemplate):
         return new_x, ry
 
     @staticmethod
-    def set_x_value(self, func, value):
+    def set_x_value(func, value):
         func.set_beta(value)
         return func
 
     @staticmethod
-    def set_y_value(self, func, value):
+    def set_y_value(func, value):
         func.set_FWHM(value)
         return func
 
     @staticmethod
-    def N(self):
+    def N():
         return 1

--- a/src/quasielasticbayes/v2_python/workflows/grid_search/qse_grid_search.py
+++ b/src/quasielasticbayes/v2_python/workflows/grid_search/qse_grid_search.py
@@ -1,4 +1,4 @@
-from quasielasticbayes.v2.workflow.grid_search import GridSearchTemplate
+from quasielasticbayes.v2.workflow.grid_template import GridSearchTemplate
 # from quasielasticbayes.v2.functions.qse_fixed import QSEFunction
 from quasielasticbayes.v2.utils.spline import spline
 from numpy import ndarray

--- a/src/quasielasticbayes/v2_python/workflows/grid_search/qse_grid_search.py
+++ b/src/quasielasticbayes/v2_python/workflows/grid_search/qse_grid_search.py
@@ -91,4 +91,4 @@ class QSEGridSearch(GridSearchTemplate):
         :param func: the fitting function
         :return the number of features
         """
-        return func.N_peaks()
+        return func.N_peaks

--- a/src/quasielasticbayes/v2_python/workflows/model_selection/model_template.py
+++ b/src/quasielasticbayes/v2_python/workflows/model_selection/model_template.py
@@ -1,0 +1,135 @@
+from quasielasticbayes.v2.functions.base import BaseFitFunction
+from quasielasticbayes.v2.workflow.template import WorkflowTemplate
+
+from quasielasticbayes.v2.log_likelihood import loglikelihood
+
+from numpy import ndarray
+import numpy as np
+from typing import Dict
+from abc import abstractmethod
+
+
+class ModelSelectionWorkflow(WorkflowTemplate):
+    """
+    This is a class for the quick bayes model selection workflow.
+    Each method can be overwritten to provide
+    unique functionality for the specific
+    use case.
+
+    The inherited class must include:
+    - _update_function method to increment the fit function
+
+    The properties are:
+    - fit_engine
+    - get_parameters_and_errors
+
+    To add a fit engine:
+    - set_scipy_engine (scipy curve fit)
+    - set_gofit_engine (gofit)
+
+    Other methods:
+    - preprocess_data
+    - update_fit_engine
+    - update_function (call this one not the overwritten one)
+    - report
+    - execute
+    """
+
+    @property
+    def get_parameters_and_errors(self) -> (Dict[str, float],
+                                            Dict[str, float]):
+        """
+        Method to get the dict's of the fit parameters and errors.
+        :return dict of fit parameters, dict of fit parameter errors
+        """
+        return self._results_dict, self._errors_dict
+
+    @abstractmethod
+    def _update_function(self, func: BaseFitFunction) -> BaseFitFunction:
+        """
+        This method updates the fitting function when the number of
+        features has been incremented.
+        It will be unique to the workflow.
+        :param func: the fitting function that needs modifing
+        :return the modified fitting function
+        """
+        raise NotImplementedError()
+
+    def update_function(self, func: BaseFitFunction,
+                        N: int) -> BaseFitFunction:
+        """
+        This method updates the fitting function when the number of
+        features has been incremented.
+        It will be unique to the workflow.
+        :param func: the fitting function that needs modifying
+        :return the modified fitting function
+        """
+        function = self._update_function(func)
+        function.update_prefix(f'N{N}:')
+        return function
+
+    def report(self, func: BaseFitFunction, N: int, beta: float) -> ndarray:
+        """
+        Reports the latest fit parameters and records the fit
+        parameters and their errors into dicts.
+        :param func: the fitting function used
+        :param N: the number of features used
+        :param beta: the beta scaling factor
+        :return the fit parameters
+        """
+        params, errors = self._engine.get_fit_parameters()
+
+        self._results_dict = func.report(self._results_dict, *params)
+        self._errors_dict = func.report_errors(self._errors_dict,
+                                               errors, params)
+
+        prob_name = f'N{N}:loglikelihood'
+        n_data = len(self._data['y'])
+        chi2 = self._engine.get_chi_squared()
+        covar = self._engine.get_covariance_matrix()
+
+        if prob_name in self._results_dict.keys():
+            self._results_dict[prob_name].append(loglikelihood(n_data,
+                                                               chi2,
+                                                               covar,
+                                                               N, beta))
+        else:
+            self._results_dict[prob_name] = [loglikelihood(n_data,
+                                                           chi2,
+                                                           covar,
+                                                           N, beta)]
+
+        return params
+
+    def execute(self, max_num_features: int,
+                func: BaseFitFunction,
+                params: ndarray = []) -> BaseFitFunction:
+        """
+        The main part of the analysis.
+        It increments the number of features in the fitting function,
+        does a fit and then records the results.
+        :param max_num_features: the maximum number of features
+        :param func: the fitting function
+        :param params: the (optional) initial fit parameters
+        :return the update fitting function
+        """
+        if self._data is None:
+            raise ValueError("self._data must be set, "
+                             "using preprocess_data or "
+                             "an equivalent method")
+        elif self._engine is None:
+            raise ValueError("A fitting engine must be set, "
+                             "by calling one of: \n"
+                             "set_scipy_engine")
+
+        beta = np.max(self._data['y'])*(np.max(self._data['x']) -
+                                        np.min(self._data['x']))
+
+        for N in range(1, max_num_features + 1):
+            func = self.update_function(func, N)
+            self.update_fit_engine(func, params)
+
+            self._engine.do_fit(self._data['x'], self._data['y'],
+                                self._data['e'], func)
+
+            params = self.report(func, N, beta)

--- a/src/quasielasticbayes/v2_python/workflows/model_selection/model_template.py
+++ b/src/quasielasticbayes/v2_python/workflows/model_selection/model_template.py
@@ -35,6 +35,17 @@ class ModelSelectionWorkflow(WorkflowTemplate):
     - execute
     """
 
+    def __init__(self, results: Dict[str, ndarray],
+                 results_errors: Dict[str, ndarray]):
+        """
+        Set the results and error dicts for reporting
+        :param results: dict of parameter values
+        :param results_errors: dict of parameter errors
+        """
+        self._results_dict = results
+        self._errors_dict = results_errors
+        super().__init__()
+
     @property
     def get_parameters_and_errors(self) -> (Dict[str, float],
                                             Dict[str, float]):

--- a/src/quasielasticbayes/v2_python/workflows/model_selection/model_template.py
+++ b/src/quasielasticbayes/v2_python/workflows/model_selection/model_template.py
@@ -61,7 +61,7 @@ class ModelSelectionWorkflow(WorkflowTemplate):
         This method updates the fitting function when the number of
         features has been incremented.
         It will be unique to the workflow.
-        :param func: the fitting function that needs modifing
+        :param func: the fitting function that needs modifying
         :return the modified fitting function
         """
         raise NotImplementedError()

--- a/src/quasielasticbayes/v2_python/workflows/model_selection/muon_exp_decay_main.py
+++ b/src/quasielasticbayes/v2_python/workflows/model_selection/muon_exp_decay_main.py
@@ -2,13 +2,13 @@ from quasielasticbayes.v2.functions.composite import CompositeFunction
 from quasielasticbayes.v2.functions.exp_decay import ExpDecay
 from quasielasticbayes.v2.utils.general import get_background_function
 from quasielasticbayes.v2.utils.crop_data import crop
-from quasielasticbayes.v2.workflow.template import Workflow
+from quasielasticbayes.v2.workflow.model_template import ModelSelectionWorkflow
 from quasielasticbayes.v2.functions.base import BaseFitFunction
 from numpy import ndarray
 from typing import Dict, List
 
 
-class MuonExpDecay(Workflow):
+class MuonExpDecay(ModelSelectionWorkflow):
     """
     A class for the muon exponential decay workflow
     """

--- a/src/quasielasticbayes/v2_python/workflows/model_selection/qldata_main.py
+++ b/src/quasielasticbayes/v2_python/workflows/model_selection/qldata_main.py
@@ -1,18 +1,17 @@
-from quasielasticbayes.v2.functions.qse_function import QSEFunction
+from quasielasticbayes.v2.functions.qldata_function import QlDataFunction
 from quasielasticbayes.v2.utils.spline import spline
 from quasielasticbayes.v2.utils.general import get_background_function
-from quasielasticbayes.v2.workflow.template import Workflow
+from quasielasticbayes.v2.workflow.model_template import ModelSelectionWorkflow
 from quasielasticbayes.v2.functions.base import BaseFitFunction
-
 
 from numpy import ndarray
 import numpy as np
 from typing import Dict, List
 
 
-class QlStretchedExp(Workflow):
+class QLData(ModelSelectionWorkflow):
     """
-    A class for the quasielastic stretched exponential workflow
+    A class for the quasielastic lorentzian workflow
     """
     def preprocess_data(self, x_data: ndarray,
                         y_data: ndarray, e_data: ndarray,
@@ -43,51 +42,26 @@ class QlStretchedExp(Workflow):
     @staticmethod
     def _update_function(func: BaseFitFunction) -> BaseFitFunction:
         """
-        Adds a single stretched exponential to the fitting function.
-        :param func: the fitting function that needs modifing
+        This method adds a single lorentzian to the fitting function
+        :param func: the fitting function that needs modifying
         :return the modified fitting function
         """
-        func.add_single_SE()
+        func.add_single_lorentzian()
         return func
 
-    def update_scipy_fit_engine(self, func: BaseFitFunction, params: ndarray):
-        """
-        This updates the bounds and guess for scipy
-        fit engine.
-        :param func: the fitting function
-        :param params: the fitting parameters
-        """
 
-        lower, upper = func.get_bounds()
-        # get estimate for FWHM -> tau
-        new_x = self._data['x']
-        y_max = np.max(self._data['y'])
-        tmp = np.where(self._data['y'] > y_max/2.)
-        est_FWHM = new_x[tmp[0][-1]] - new_x[tmp[0][0]]
-        guess = []
-        if len(params) == len(upper):
-            guess = params
-        else:
-            guess = func.get_func_guess()
-            guess[2] = est_FWHM
-            func.set_func_guess_FWHM(guess)
-            guess = func.get_guess()
-        self._engine.set_guess_and_bounds(guess, lower, upper)
-
-
-def qse_data_main(sample: Dict[str, ndarray], res: Dict[str, ndarray],
-                  BG_type: str, start_x: float, end_x: float,
-                  elastic: bool,
-                  results: Dict[str, ndarray],
-                  results_errors: Dict[str, ndarray],
-                  init_params: List[float] = None) -> (Dict[str, ndarray],
-                                                       Dict[str, ndarray],
-                                                       ndarray,
-                                                       List[ndarray],
-                                                       List[ndarray]):
+def ql_data_main(sample: Dict[str, ndarray], res: Dict[str, ndarray],
+                 BG_type: str, start_x: float, end_x: float,
+                 elastic: bool,
+                 results: Dict[str, ndarray],
+                 results_errors: Dict[str, ndarray],
+                 init_params: List[float] = None) -> (Dict[str, ndarray],
+                                                      Dict[str, ndarray],
+                                                      ndarray,
+                                                      List[ndarray],
+                                                      List[ndarray]):
     """
-    The main function for calculating QSEdata.
-    This uses the stretch exponential workflow
+    Method for wrapping the qldata workflow.
     :param sample: dict containing the sample x, y and e data (keys = x, y, e)
     :param res: dict containing the resolution x, y data (keys = x, y)
     :param BG_type: the type of BG ("none", "flat", "linear")
@@ -95,29 +69,27 @@ def qse_data_main(sample: Dict[str, ndarray], res: Dict[str, ndarray],
     :param end_x: the end x for the calculation
     :param elastic: if to include the elastic peak
     :param results: dict of results
-    :param results_errors: the dict of parameter errors
-    :param init_params: initial values, if None (default) a guess will be made
-    :result dict of the fit parameters, their errors, the x range used, list
-    of fit values and their errors.
+    :param results_errors: dict of errors for results
+    :param init_params: initial values, if None a guess will be made
+    :result dict of the fit parameters, their errors, the x range used, list of
+    fit values and their errors.
     """
+
     # setup workflow
-    workflow = QlStretchedExp(results, results_errors)
+    workflow = QLData(results, results_errors)
     new_x, ry = workflow.preprocess_data(sample['x'], sample['y'],
                                          sample['e'],
                                          start_x, end_x, res)
 
-    max_num_peaks = 1
+    max_num_peaks = 3
 
     # setup fit function
     BG = get_background_function(BG_type)
-    func = QSEFunction(BG, elastic, new_x, ry, start_x, end_x)
+    func = QlDataFunction(BG, elastic, new_x, ry, start_x, end_x)
     lower, upper = func.get_bounds()
-    """
-    if the parameters have come in from another calculation bounds won't match
-    because it will be missing the stretched exp terms
-    """
 
     params = init_params if init_params is not None else func.get_guess()
+    # just want a guess the same length as lower, it is not used
     workflow.set_scipy_engine(func.get_guess(), lower, upper)
 
     # do the calculation

--- a/src/quasielasticbayes/v2_python/workflows/workflow_template.py
+++ b/src/quasielasticbayes/v2_python/workflows/workflow_template.py
@@ -3,30 +3,25 @@ from quasielasticbayes.v2.fitting.gofit_engine import GoFitEngine
 from quasielasticbayes.v2.functions.base import BaseFitFunction
 
 from quasielasticbayes.v2.utils.general import update_guess
-from quasielasticbayes.v2.log_likelihood import loglikelihood
 
 from numpy import ndarray
-import numpy as np
 from typing import Dict
 from abc import abstractmethod
 
 
-class Workflow(object):
+class WorkflowTemplate(object):
     """
     This is a class for the quick bayes workflow.
     Each method can be overwritten to provide
     unique functionality for the specific
     use case.
 
-    The inherited class must include:
-    - _update_function method to increment the fit function
-
     The properties are:
     - fit_engine
-    - get_parameters_and_errors
 
     To add a fit engine:
     - set_scipy_engine (scipy curve fit)
+    - set_gofit_engine (gofit)
 
     Other methods:
     - preprocess_data
@@ -34,7 +29,6 @@ class Workflow(object):
     - update_function (call this one not the overwritten one)
     - report
     - execute
-    - update_scipy_fit_engine
     """
     def __init__(self, results: Dict[str, ndarray],
                  results_errors: Dict[str, ndarray]):
@@ -55,15 +49,6 @@ class Workflow(object):
         :return the fit engine used
         """
         return self._engine
-
-    @property
-    def get_parameters_and_errors(self) -> (Dict[str, float],
-                                            Dict[str, float]):
-        """
-        Method to get the dict's of the fit parameters and errors.
-        :return dict of fit parameters, dict of fit parameter errors
-        """
-        return self._results_dict, self._errors_dict
 
     def preprocess_data(self, x_data: ndarray,
                         y_data: ndarray, e_data: ndarray,
@@ -102,94 +87,14 @@ class Workflow(object):
         return
 
     @abstractmethod
-    def _update_function(self, func: BaseFitFunction) -> BaseFitFunction:
-        """
-        This method updates the fitting function when the number of
-        features has been incremented.
-        It will be unique to the workflow.
-        :param func: the fitting function that needs modifing
-        :return the modified fitting function
-        """
-        raise NotImplementedError()
-
-    def update_function(self, func: BaseFitFunction,
-                        N: int) -> BaseFitFunction:
-        """
-        This method updates the fitting function when the number of
-        features has been incremented.
-        It will be unique to the workflow.
-        :param func: the fitting function that needs modifying
-        :return the modified fitting function
-        """
-        function = self._update_function(func)
-        function.update_prefix(f'N{N}:')
-        return function
-
-    def report(self, func: BaseFitFunction, N: int, beta: float) -> ndarray:
-        """
-        Reports the latest fit parameters and records the fit
-        parameters and their errors into dicts.
-        :param func: the fitting function used
-        :param N: the number of features used
-        :param beta: the beta scaling factor
-        :return the fit parameters
-        """
-        params, errors = self._engine.get_fit_parameters()
-
-        self._results_dict = func.report(self._results_dict, *params)
-        self._errors_dict = func.report_errors(self._errors_dict,
-                                               errors, params)
-
-        prob_name = f'N{N}:loglikelihood'
-        n_data = len(self._data['y'])
-        chi2 = self._engine.get_chi_squared()
-        covar = self._engine.get_covariance_matrix()
-
-        if prob_name in self._results_dict.keys():
-            self._results_dict[prob_name].append(loglikelihood(n_data,
-                                                               chi2,
-                                                               covar,
-                                                               N, beta))
-        else:
-            self._results_dict[prob_name] = [loglikelihood(n_data,
-                                                           chi2,
-                                                           covar,
-                                                           N, beta)]
-
-        return params
-
-    def execute(self, max_num_features: int,
-                func: BaseFitFunction,
-                params: ndarray = []) -> BaseFitFunction:
+    def execute(self, *args) -> None:
         """
         The main part of the analysis.
         It increments the number of features in the fitting function,
         does a fit and then records the results.
-        :param max_num_features: the maximum number of features
-        :param func: the fitting function
-        :param params: the (optional) initial fit parameters
-        :return the update fitting function
+        :param args: the arguments
         """
-        if self._data is None:
-            raise ValueError("self._data must be set, "
-                             "using preprocess_data or "
-                             "an equivalent method")
-        elif self._engine is None:
-            raise ValueError("A fitting engine must be set, "
-                             "by calling one of: \n"
-                             "set_scipy_engine")
-
-        beta = np.max(self._data['y'])*(np.max(self._data['x']) -
-                                        np.min(self._data['x']))
-
-        for N in range(1, max_num_features + 1):
-            func = self.update_function(func, N)
-            self.update_fit_engine(func, params)
-
-            self._engine.do_fit(self._data['x'], self._data['y'],
-                                self._data['e'], func)
-
-            params = self.report(func, N, beta)
+        raise NotImplementedError()
 
     def _check_engine_and_data_set_valid(self) -> None:
         """

--- a/src/quasielasticbayes/v2_python/workflows/workflow_template.py
+++ b/src/quasielasticbayes/v2_python/workflows/workflow_template.py
@@ -5,7 +5,6 @@ from quasielasticbayes.v2.functions.base import BaseFitFunction
 from quasielasticbayes.v2.utils.general import update_guess
 
 from numpy import ndarray
-from typing import Dict
 from abc import abstractmethod
 
 
@@ -27,19 +26,13 @@ class WorkflowTemplate(object):
     - preprocess_data
     - update_fit_engine
     - update_function (call this one not the overwritten one)
-    - report
     - execute
     """
-    def __init__(self, results: Dict[str, ndarray],
-                 results_errors: Dict[str, ndarray]):
+    def __init__(self):
         """
         Set the results and error dicts for reporting
-        :param results: dict of parameter values
-        :param results_errors: dict of parameter errors
         """
         self._engine = None
-        self._results_dict = results
-        self._errors_dict = results_errors
         self._data = None
 
     @property

--- a/test/fit_functions/SEWithFixes_test.py
+++ b/test/fit_functions/SEWithFixes_test.py
@@ -1,0 +1,133 @@
+import unittest
+import numpy as np
+from quasielasticbayes.v2.functions.SE import StretchExp
+from quasielasticbayes.v2.functions.SE_fix import StretchExpWithFixes
+
+
+class StretchExpWithFixesTest(unittest.TestCase):
+
+    """
+    Since this function is calling a tested fit
+    function, but with some fixed parameters
+    we will test the values by using the original
+    function. Hence, we are assuming that the
+    values of the function are sufficently
+    tested by the StretchExp tests.
+    Allowing us to focus on the fixes.
+    """
+    def test_beta(self):
+        se = StretchExpWithFixes()
+        self.assertEqual(se.get_beta, 0.8)
+
+        se.set_beta(0.9)
+        self.assertEqual(se.get_beta, 0.9)
+
+    def test_init_values(self):
+        se = StretchExpWithFixes(beta=0.9, FWHM=0.12)
+
+        self.assertEqual(se.get_beta, 0.9)
+        self.assertAlmostEqual(se.get_tau, 10.970, 3)
+
+    def test_FWHM(self):
+        se = StretchExpWithFixes()
+        self.assertAlmostEqual(se.get_tau, 6.582, 3)
+
+        se.set_FWHM(0.9)
+        self.assertAlmostEqual(se.get_tau, 1.463, 3)
+
+    def test_call(self):
+        x = np.linspace(-0.4, 0.4, 6)
+
+        se = StretchExp()
+        se_fix = StretchExpWithFixes()
+
+        expect = se(x, 1.0, 0.01, se.tau(.1), .7)
+
+        se_fix.set_beta(0.7)
+        se_fix.set_FWHM(.1)
+        y = se_fix(x, 1.0, 0.01)
+
+        self.assertEqual(len(y), len(expect))
+        for j in range(len(y)):
+            self.assertAlmostEqual(y[j], expect[j], 3)
+
+    def test_report(self):
+        report = {"old": [1]}
+
+        se = StretchExpWithFixes()
+        se.set_beta(0.5)
+        se.set_FWHM(0.132)
+        out = se.report(report, 1, 0.1)
+
+        self.assertEqual(out["Amplitude"], [1])
+        self.assertEqual(out["Peak Centre"], [0.1])
+        self.assertAlmostEqual(out["tau"][0], 9.973, 3)
+        self.assertEqual(out["FWHM"], [0.132])
+        self.assertEqual(out["beta"], [0.5])
+        self.assertEqual(out["old"], [1])
+        self.assertEqual(len(out.keys()), 6)
+
+    def test_errors_report(self):
+        report = {"old": [1]}
+
+        se = StretchExpWithFixes()
+        errors = np.array([0.1, 0.02])
+        params = np.array([1, .2])
+        out = se.report_errors(report, errors, params)
+
+        self.assertEqual(out["Amplitude"], [0.1])
+        self.assertEqual(out["Peak Centre"], [0.02])
+        self.assertEqual(out["tau"], [0.])
+        self.assertEqual(out["FWHM"], [0.0])
+        self.assertEqual(out["beta"], [0.0])
+        self.assertEqual(out["old"], [1])
+        self.assertEqual(len(out.keys()), 6)
+
+    def test_read(self):
+        report = {"old": [1]}
+
+        se = StretchExp()
+        out = se.report(report, 1, 0.1, 10, .5)
+
+        se_fix = StretchExpWithFixes()
+        params = se_fix.read_from_report(out, 0)
+
+        self.assertEqual(params, [1, 0.1])
+        self.assertEqual(se_fix.get_tau, 10)
+        self.assertEqual(se_fix.get_beta, .5)
+
+    def test_set_FWHM(self):
+        se = StretchExpWithFixes(FWHM=.2)
+        self.assertAlmostEqual(se.get_tau, 6.582, 3)
+        se.set_FWHM(0.376)
+        self.assertAlmostEqual(se.get_tau, 3.501, 3)
+
+    def test_N_params(self):
+        se = StretchExpWithFixes()
+        self.assertEqual(se.N_params, 2)
+
+    def test_guess(self):
+        se = StretchExpWithFixes()
+        guess = se.get_guess()
+        expect = [0.1, 0.0]
+        self.assertEqual(len(guess), len(expect))
+        for k in range(len(guess)):
+            self.assertAlmostEqual(guess[k], expect[k], 3)
+
+        se.set_guess([1, 2])
+        self.assertEqual(se.get_guess(), [1, 2])
+
+    def test_bounds(self):
+        se = StretchExpWithFixes()
+        bounds = se.get_bounds()
+        self.assertEqual(bounds[0], [0, -1.])
+        self.assertEqual(bounds[1], [1., 1])
+
+        se.set_bounds([-1, -2], [3, 4])
+        bounds = se.get_bounds()
+        self.assertEqual(bounds[0], [-1, -2.])
+        self.assertEqual(bounds[1], [3., 4])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/fit_functions/SEWithFixes_test.py
+++ b/test/fit_functions/SEWithFixes_test.py
@@ -11,7 +11,7 @@ class StretchExpWithFixesTest(unittest.TestCase):
     function, but with some fixed parameters
     we will test the values by using the original
     function. Hence, we are assuming that the
-    values of the function are sufficently
+    values of the function are sufficiently
     tested by the StretchExp tests.
     Allowing us to focus on the fixes.
     """

--- a/test/fit_functions/qseFixedFunction_test.py
+++ b/test/fit_functions/qseFixedFunction_test.py
@@ -1,0 +1,502 @@
+import unittest
+import numpy as np
+from quasielasticbayes.v2.functions.BG import LinearBG
+from quasielasticbayes.v2.functions.SE import StretchExp
+from quasielasticbayes.v2.functions.qse_fixed import QSEFixFunction
+
+
+class QSEFixedFunctionTest(unittest.TestCase):
+
+    def test_just_bg(self):
+        x = np.linspace(0, 5, 6)
+        bg = LinearBG()
+        qse = QSEFixFunction(bg, False, x, x, 0, 6)
+        y = qse(x, 1.2, 3)
+        expect = 1.2*x + 3
+
+        self.assertEqual(qse.N_params, 2)
+        for j in range(len(x)):
+            self.assertAlmostEqual(y[j], expect[j])
+
+        self.assertEqual(qse.get_guess(), [0., 0.])
+
+        bounds = qse.get_bounds()
+        self.assertEqual(bounds[0], [-1, -1])
+        self.assertEqual(bounds[1], [1, 1])
+
+        report = {}
+        report = qse.report(report, 1, 2)
+        self.assertEqual(report["N0:f1.BG gradient"], [1.])
+        self.assertEqual(report["N0:f1.BG constant"], [2.])
+
+    def test_read_just_bg(self):
+        x = np.linspace(0, 5, 6)
+        bg = LinearBG()
+        qse = QSEFixFunction(bg, False, x, x, 0, 6)
+        report = {}
+        report = qse.report(report, 1., 2.3)
+        params = qse.read_from_report(report, 0)
+        self.assertEqual(params, [1., 2.3])
+
+    def test_bg_and_delta(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+
+        se = StretchExp()
+        y = se(x, 1., 0.01, 11, .7)
+
+        qse = QSEFixFunction(bg, True, x, y, -6, 6)
+        y = qse(x, 1.2, 3, .2, .1)
+        expect = [-3, 0.0001, 3.080, 6.000, 9.000]
+
+        self.assertEqual(qse.get_guess(), [0., 0., 1., 0.])
+
+        bounds = qse.get_bounds()
+        self.assertEqual(bounds[0], [-1, -1, 0., -1])
+        self.assertEqual(bounds[1], [1, 1, np.inf, 1])
+
+        self.assertEqual(qse.N_params, 4)
+        for j in range(len(x)):
+            self.assertAlmostEqual(y[j], expect[j], 3)
+
+        report = {}
+        report = qse.report(report, 1, 2, 3, 4)
+        self.assertEqual(len(report.keys()), 4)
+        self.assertEqual(report["N0:f1.BG gradient"], [1.])
+        self.assertEqual(report["N0:f1.BG constant"], [2.])
+
+        self.assertEqual(report["N0:f2.f1.Amplitude"], [3.])
+        self.assertEqual(report["N0:f2.f1.Centre"], [4])
+
+    def test_read_bg_and_delta(self):
+        x = np.linspace(0, 5, 6)
+        bg = LinearBG()
+        qse = QSEFixFunction(bg, True, x, x, 0, 6)
+        report = {}
+        report = qse.report(report, 1., 2.3, .5, -.1)
+        params = qse.read_from_report(report, 0)
+        self.assertEqual(params, [1., 2.3, .5, -.1])
+
+    def test_bg_and_delta_and_1_SE(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+
+        se = StretchExp()
+        y = se(x, 1., 0.01, 11, .7)
+
+        qse = QSEFixFunction(bg, True, x, y, -6, 6)
+        qse.add_single_SE()
+
+        y = qse(x, .02, 1, .2, .1, 1)
+        expect = [0.904, 0.961, 2.445, 1.062, 1.104]
+
+        bounds = qse.get_bounds()
+        self.assertEqual(bounds[0], [-1, -1, 0., -1, 0.])
+        self.assertEqual(bounds[1], [1, 1, np.inf, 1, 1])
+
+        # shared param (peak centre)
+        self.assertEqual(qse.N_params, 5)
+        for j in range(len(x)):
+            self.assertAlmostEqual(y[j], expect[j], 3)
+
+        guess = qse.get_guess()
+        expect = [0., 0., 1., 0., 0.1]
+        self.assertEqual(len(guess), len(expect))
+        for k in range(len(expect)):
+            self.assertAlmostEqual(guess[k], expect[k], 3)
+
+        report = {}
+        report = qse.report(report, 1, 2, 3., 4, 5.)
+        self.assertEqual(len(report.keys()), 9)
+        self.assertEqual(report["N1:f1.BG gradient"], [1.])
+        self.assertEqual(report["N1:f1.BG constant"], [2.])
+
+        self.assertEqual(report["N1:f2.f1.Amplitude"], [3.])
+        self.assertEqual(report["N1:f2.f1.Centre"], [4])
+
+        self.assertEqual(report["N1:f2.f2.Amplitude"], [5])
+        self.assertEqual(report["N1:f2.f2.Peak Centre"], [4])
+        self.assertAlmostEqual(report["N1:f2.f2.tau"][0], 6.582, 3)
+        self.assertEqual(report["N1:f2.f2.FWHM"], [0.2])
+        self.assertEqual(report["N1:f2.f2.beta"], [0.8])
+
+    def test_read_bg_and_delta_and_1se(self):
+        x = np.linspace(0, 5, 6)
+        bg = LinearBG()
+        qse = QSEFixFunction(bg, True, x, x, 0, 6)
+        qse.add_single_SE()
+        report = {}
+        report = qse.report(report, 1., 2.3, .5, -.1, .1)
+        params = qse.read_from_report(report, 1)
+        self.assertEqual(params, [1., 2.3, .5, -.1, .1])
+
+    def test_bg_and_1_SE(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+
+        se = StretchExp()
+        y = se(x, 1., 0.01, 11, .7)
+
+        qse = QSEFixFunction(bg, False, x, y, -6, 6)
+        qse.add_single_SE()
+
+        y = qse(x, .02, 1, 1, .1)
+        expect = [0.904, 0.961, 2.365, 1.062, 1.104]
+
+        bounds = qse.get_bounds()
+        self.assertEqual(bounds[0], [-1, -1, 0., -1])
+        self.assertEqual(bounds[1], [1, 1, 1, 1])
+
+        # shared param (peak centre)
+        self.assertEqual(qse.N_params, 4)
+        for j in range(len(x)):
+            self.assertAlmostEqual(y[j], expect[j], 3)
+
+        expect = [0., 0., 0.1, 0.]
+        guess = qse.get_guess()
+        self.assertEqual(len(guess), len(expect))
+        for k in range(len(expect)):
+            self.assertAlmostEqual(guess[k], expect[k], 3)
+
+        report = {}
+        report = qse.report(report, 1, 2, 3., 4)
+        self.assertEqual(len(report.keys()), 7)
+        self.assertEqual(report["N1:f1.BG gradient"], [1.])
+        self.assertEqual(report["N1:f1.BG constant"], [2.])
+
+        self.assertEqual(report["N1:f2.f1.Amplitude"], [3])
+        self.assertEqual(report["N1:f2.f1.Peak Centre"], [4])
+        self.assertAlmostEqual(report["N1:f2.f1.tau"][0], 6.582, 3)
+        self.assertEqual(report["N1:f2.f1.FWHM"][0], 0.2)
+        self.assertEqual(report["N1:f2.f1.beta"], [0.8])
+
+    def test_read_bg_and_1se(self):
+        x = np.linspace(0, 5, 6)
+        bg = LinearBG()
+        qse = QSEFixFunction(bg, False, x, x, 0, 6)
+        qse.add_single_SE()
+        report = {}
+        report = qse.report(report, 1., 2.3, .1, -.1)
+        params = qse.read_from_report(report, 1)
+        self.assertEqual(params, [1., 2.3, .1, -.1])
+
+    def assertList(self, values, expected):
+        self.assertEqual(len(values), len(expected))
+        for k in range(len(values)):
+            self.assertAlmostEqual(values[k], values[k], 3)
+
+    def test_set_delta_guess(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+        ql = QSEFixFunction(bg, True, x, x + 1, -6, 6)
+        self.assertEqual(ql.get_guess(), [0, 0, 1., 0])
+
+        ql.set_delta_guess([3, 1])
+        self.assertEqual(ql.get_guess(), [0, 0, 3., 1])
+
+    def test_set_delta_guess_fail(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+        ql = QSEFixFunction(bg, False, x, x + 1, -6, 6)
+        self.assertEqual(ql.get_guess(), [0, 0])
+
+        ql.set_delta_guess([3, 1])
+        self.assertEqual(ql.get_guess(), [0, 0])
+
+    def test_set_BG_guess(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+        ql = QSEFixFunction(bg, True, x, x + 1, -6, 6)
+        self.assertEqual(ql.get_guess(), [0, 0, 1., 0])
+
+        ql.set_BG_guess([3, 1])
+        self.assertEqual(ql.get_guess(), [3, 1, 1., 0])
+
+    def test_set_func_no_peak(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+        ql = QSEFixFunction(bg, True, x, x + 1, -6, 6)
+        self.assertEqual(ql.get_guess(), [0, 0, 1., 0])
+
+        ql.set_func_guess([3, 2, 1, 4])
+        self.assertEqual(ql.get_guess(), [0, 0, 1., 0])
+
+    def test_set_func_one_peak_no_delta(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+        ql = QSEFixFunction(bg, False, x, x + 1, -6, 6)
+        ql.add_single_SE()
+        self.assertList(ql.get_guess(), [0, 0, 0.1, 0])
+
+        ql.set_func_guess([3, 2])
+        self.assertList(ql.get_guess(), [0, 0, 3, 2])
+
+    def test_set_func_one_peak_and_delta(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+        ql = QSEFixFunction(bg, True, x, x + 1, -6, 6)
+        ql.add_single_SE()
+        self.assertList(ql.get_guess(), [0, 0, 1, 0, 0.1])
+
+        ql.set_func_guess([3, 2])
+        self.assertList(ql.get_guess(), [0, 0, 1, 2, 3])
+
+    def test_set_func_two_peak_no_delta(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+        ql = QSEFixFunction(bg, False, x, x + 1, -6, 6)
+        ql.add_single_SE()
+        ql.add_single_SE()
+        self.assertList(ql.get_guess(), [0, 0, 0.1, 0, 0.1])
+
+        ql.set_func_guess([3, 2])
+        self.assertList(ql.get_guess(), [0, 0, 0.1, 2, 3])
+
+        ql.set_func_guess([6, 5], 0)
+        self.assertList(ql.get_guess(), [0, 0, 6, 5, 3])
+
+    def test_set_func_two_peak_and_delta(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+        ql = QSEFixFunction(bg, True, x, x + 1, -6, 6)
+        ql.add_single_SE()
+        ql.add_single_SE()
+        self.assertList(ql.get_guess(), [0, 0, 1., 0, 0.1, 0.1])
+
+        ql.set_func_guess([3, 2])
+        self.assertList(ql.get_guess(), [0, 0, 1., 2, 0.1, 3])
+
+        ql.set_func_guess([4, 5], 0)
+        self.assertList(ql.get_guess(), [0, 0, 1., 5, 4, 3])
+
+    def test_get_func_guess(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+        ql = QSEFixFunction(bg, True, x, x + 1, -6, 6)
+        ql.add_single_SE()
+        ql.add_single_SE()
+        self.assertList(ql.get_guess(), [0, 0, 1., 0, 0.1, 0.1])
+
+        ql.set_func_guess([3, 2])
+        self.assertList(ql.get_guess(), [0, 0, 1., 2, 0.1, 3])
+
+        ql.set_func_guess([4, 5], 0)
+        self.assertList(ql.get_guess(), [0, 0, 1., 5, 4, 3])
+        self.assertList(ql.get_guess(), [0, 0, 1., 5, 4, 3])
+
+        self.assertEqual(ql.get_func_guess(), [3, 5])
+        self.assertEqual(ql.get_func_guess(0), [4, 5])
+
+    def test_set_delta_bounds(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+        ql = QSEFixFunction(bg, True, x, x + 1, -6, 6)
+        lower, upper = ql.get_bounds()
+        self.assertEqual(lower, [-1, -1, 0, -1])
+        self.assertEqual(upper, [1, 1, np.inf, 1])
+
+        ql.set_delta_bounds([-3, -2], [2, 4])
+        lower, upper = ql.get_bounds()
+        self.assertEqual(lower, [-1, -1, -3, -2])
+        self.assertEqual(upper, [1, 1, 2, 4])
+
+    def test_set_delta_bounds_fail(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+        ql = QSEFixFunction(bg, False, x, x + 1, -6, 6)
+        lower, upper = ql.get_bounds()
+        self.assertEqual(lower, [-1, -1])
+        self.assertEqual(upper, [1, 1])
+
+        ql.set_delta_bounds([-3, -2], [2, 4])
+        lower, upper = ql.get_bounds()
+        self.assertEqual(lower, [-1, -1])
+        self.assertEqual(upper, [1, 1])
+
+    def test_set_BG_bounds(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+        ql = QSEFixFunction(bg, True, x, x + 1, -6, 6)
+
+        lower, upper = ql.get_bounds()
+        self.assertEqual(lower, [-1, -1, 0, -1])
+        self.assertEqual(upper, [1, 1, np.inf, 1])
+
+        ql.set_BG_bounds([-3, -2], [2, 4])
+        lower, upper = ql.get_bounds()
+        self.assertEqual(lower, [-3, -2, 0, -1])
+        self.assertEqual(upper, [2, 4, np.inf, 1])
+
+    def test_set_func_bounds_no_peak(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+        ql = QSEFixFunction(bg, True, x, x + 1, -6, 6)
+        lower, upper = ql.get_bounds()
+        self.assertEqual(lower, [-1, -1, 0, -1])
+        self.assertEqual(upper, [1, 1, np.inf, 1])
+
+        ql.set_func_bounds([-3, -2, 1], [1, 2, 4])
+        lower, upper = ql.get_bounds()
+        self.assertEqual(lower, [-1, -1, 0, -1])
+        self.assertEqual(upper, [1, 1, np.inf, 1])
+
+    def test_set_func_bounds_one_peak_no_delta(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+        ql = QSEFixFunction(bg, False, x, x + 1, -6, 6)
+        ql.add_single_SE()
+
+        lower, upper = ql.get_bounds()
+        self.assertEqual(lower, [-1, -1, 0, -1])
+        self.assertEqual(upper, [1, 1, 1, 1])
+
+        ql.set_func_bounds([-3, -2], [3, 2])
+        lower, upper = ql.get_bounds()
+        self.assertEqual(lower, [-1, -1, -3, -2])
+        self.assertEqual(upper, [1, 1, 3, 2])
+
+    def test_set_func_bounds_one_peak_and_delta(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+        ql = QSEFixFunction(bg, True, x, x + 1, -6, 6)
+        ql.add_single_SE()
+
+        lower, upper = ql.get_bounds()
+        self.assertEqual(lower, [-1, -1, 0, -1, 0])
+        self.assertEqual(upper, [1, 1, np.inf, 1, 1])
+
+        ql.set_func_bounds([-3, -2], [3, 2])
+        lower, upper = ql.get_bounds()
+        self.assertEqual(lower, [-1, -1, 0, -2, -3])
+        self.assertEqual(upper, [1, 1, np.inf, 2, 3])
+
+    def test_set_func_bounds_two_peak_no_delta(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+        ql = QSEFixFunction(bg, False, x, x + 1, -6, 6)
+        ql.add_single_SE()
+        ql.add_single_SE()
+
+        lower, upper = ql.get_bounds()
+        self.assertEqual(lower, [-1, -1, 0, -1, 0])
+        self.assertEqual(upper, [1, 1, 1, 1, 1])
+
+        ql.set_func_bounds([-3, -2], [3, 2])
+        lower, upper = ql.get_bounds()
+
+        self.assertEqual(lower, [-1, -1, 0, -2, -3])
+        self.assertEqual(upper, [1, 1, 1, 2, 3])
+
+    def test_set_func_bounds_two_peak_and_delta(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+        ql = QSEFixFunction(bg, True, x, x + 1, -6, 6)
+        ql.add_single_SE()
+        ql.add_single_SE()
+
+        lower, upper = ql.get_bounds()
+        self.assertEqual(lower, [-1, -1, 0, -1, 0, 0])
+        self.assertEqual(upper, [1, 1, np.inf, 1, 1, 1])
+
+        ql.set_func_bounds([-3, -2], [3, 2])
+        lower, upper = ql.get_bounds()
+
+        self.assertEqual(lower, [-1, -1, 0, -2, 0, -3])
+        self.assertEqual(upper, [1, 1, np.inf, 2, 1, 3])
+
+        ql.set_func_bounds([-5, -6], [5, 6], 0)
+        lower, upper = ql.get_bounds()
+
+        self.assertEqual(lower, [-1, -1, 0, -6, -5, -3])
+        self.assertEqual(upper, [1, 1, np.inf, 6, 5, 3])
+
+    @staticmethod
+    def get_se(func, index):
+        return func.conv._funcs[index]
+
+    def test_beta(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+        ql = QSEFixFunction(bg, True, x, x + 1, -6, 6)
+        ql.add_single_SE()
+
+        self.assertEqual(self.get_se(ql, 1)._beta, 0.8)
+
+        ql.set_beta(0.9)
+
+        self.assertEqual(self.get_se(ql, 1)._beta, 0.9)
+
+        report = {}
+        report = ql.report(report, 1, 2, 3., 4, 5.)
+        self.assertEqual(report["N1:f2.f2.beta"], [0.9])
+
+        ql.set_beta(1.0)
+        self.assertEqual(self.get_se(ql, 1)._beta, 1.0)
+
+        _ = ql.read_from_report(report, 1)
+
+        self.assertEqual(self.get_se(ql, 1)._beta, 0.9)
+
+    def test_2_betas(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+        ql = QSEFixFunction(bg, True, x, x + 1, -6, 6)
+        ql.add_single_SE()
+        ql.add_single_SE()
+
+        self.assertEqual(self.get_se(ql, 1).get_beta, 0.8)
+        self.assertEqual(self.get_se(ql, 2).get_beta, 0.8)
+
+        ql.set_beta(0.9)
+        self.assertEqual(self.get_se(ql, 1).get_beta, 0.8)
+        self.assertEqual(self.get_se(ql, 2).get_beta, 0.9)
+
+        ql.set_beta(1.0, 0)
+        self.assertEqual(self.get_se(ql, 1).get_beta, 1.0)
+        self.assertEqual(self.get_se(ql, 2).get_beta, 0.9)
+
+    def test_tau(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+        ql = QSEFixFunction(bg, True, x, x + 1, -6, 6)
+        ql.add_single_SE()
+
+        self.assertAlmostEqual(self.get_se(ql, 1).get_tau, 6.582, 3)
+
+        ql.set_FWHM(0.4)
+
+        self.assertAlmostEqual(self.get_se(ql, 1).get_tau, 3.291, 3)
+
+        report = {}
+        report = ql.report(report, 1, 2, 3., 4, 5.)
+        self.assertEqual(report["N1:f2.f2.FWHM"], [0.4])
+
+        ql.set_FWHM(.1)
+        self.assertAlmostEqual(self.get_se(ql, 1).get_tau, 13.164, 3)
+
+        _ = ql.read_from_report(report, 1)
+
+        self.assertAlmostEqual(self.get_se(ql, 1).get_tau, 3.291, 3)
+
+    def test_2_taus(self):
+        x = np.linspace(-5, 5, 5)
+        bg = LinearBG()
+        ql = QSEFixFunction(bg, True, x, x + 1, -6, 6)
+        ql.add_single_SE()
+        ql.add_single_SE()
+
+        self.assertAlmostEqual(self.get_se(ql, 1).get_tau, 6.582, 3)
+        self.assertAlmostEqual(self.get_se(ql, 2).get_tau, 6.582, 3)
+
+        ql.set_FWHM(0.4)
+
+        self.assertAlmostEqual(self.get_se(ql, 1).get_tau, 6.582, 3)
+        self.assertAlmostEqual(self.get_se(ql, 2).get_tau, 3.291, 3)
+
+        ql.set_FWHM(.1, 0)
+        self.assertAlmostEqual(self.get_se(ql, 1).get_tau, 13.164, 3)
+        self.assertAlmostEqual(self.get_se(ql, 2).get_tau, 3.291, 3)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/workflows/grid_search/gridSearchTemplate_test.py
+++ b/test/workflows/grid_search/gridSearchTemplate_test.py
@@ -60,14 +60,12 @@ class SimpleWorkflow(GridSearchTemplate):
         return func
 
     @staticmethod
-    def set_x_value(func, value):
-        print(func, value)
+    def _set_x_value(func, value):
         func.set_c(value)
         return func
 
     @staticmethod
-    def set_y_value(func, value):
-        print(func)
+    def _set_y_value(func, value):
         func.set_m(value)
         return func
 
@@ -82,9 +80,7 @@ class GridSearchTemplateTest(unittest.TestCase):
         self.func = FixedComposite()
         lin = FixedBG()
         self.func.add_function(lin)
-        results = {}
-        errors = {}
-        self.wf = SimpleWorkflow(results, errors)
+        self.wf = SimpleWorkflow()
 
     def test_set_x_axis(self):
         self.wf.set_x_axis(1, 3, 5, 'test')
@@ -111,7 +107,7 @@ class GridSearchTemplateTest(unittest.TestCase):
     def test_grid(self):
         self.wf.set_x_axis(0, 1, 2, 'x')
         self.wf.set_y_axis(1, 2, 2, 'y')
-        X, Y = self.wf.generate_mesh()
+        X, Y = self.wf._generate_grid()
         grid = self.wf.get_grid
 
         expect_x = [[0, 1], [0, 1]]
@@ -146,8 +142,7 @@ class GridSearchTemplateTest(unittest.TestCase):
         self.wf.set_y_axis(1, 2, 2, 'y')
         self.func.add_function(ExpDecay())
         self.wf.set_scipy_engine([0, 0], [-9, -9], [9, 9])
-        results = {}
-        X, Y = self.wf.execute(self.func, results)
+        X, Y = self.wf.execute(self.func)
 
         grid = self.wf.get_grid
         expect_z = [[0.449, 1], [0, 0.115]]
@@ -169,8 +164,7 @@ class GridSearchTemplateTest(unittest.TestCase):
         self.wf.set_y_axis(1, 2, 2, 'y')
         self.func.add_function(ExpDecay())
         self.wf.set_scipy_engine([0, 0], [-9, -9], [9, 9])
-        results = {}
-        _, _ = self.wf.execute(self.func, results)
+        _, _ = self.wf.execute(self.func)
 
         x, y = self.wf.get_slices()
         expect_x = [0.449, 1]
@@ -198,21 +192,21 @@ class GridSearchTemplateTest(unittest.TestCase):
         self.wf.set_x_axis(0, 1, 2, 'x')
         self.wf.set_y_axis(1, 2, 2, 'y')
         with self.assertRaises(ValueError):
-            _, _ = self.wf.execute(self.func, {})
+            _, _ = self.wf.execute(self.func)
 
     def test_execute_no_x_axis(self):
         x, y, e = gen_data()
         self.wf.preprocess_data(x, y, e)
         self.wf.set_y_axis(1, 2, 2, 'y')
         with self.assertRaises(ValueError):
-            _, _ = self.wf.execute(self.func, {})
+            _, _ = self.wf.execute(self.func)
 
     def test_execute_no_y_axis(self):
         x, y, e = gen_data()
         self.wf.preprocess_data(x, y, e)
         self.wf.set_x_axis(0, 1, 2, 'x')
         with self.assertRaises(ValueError):
-            _, _ = self.wf.execute(self.func, {})
+            _, _ = self.wf.execute(self.func)
 
     def test_add_second_engine_errors(self):
         x, y, e = gen_data()

--- a/test/workflows/grid_search/gridSearchTemplate_test.py
+++ b/test/workflows/grid_search/gridSearchTemplate_test.py
@@ -1,0 +1,274 @@
+import unittest
+from quasielasticbayes.v2.workflow.grid_template import GridSearchTemplate
+from quasielasticbayes.v2.functions.BG import LinearBG, FlatBG
+from quasielasticbayes.v2.functions.exp_decay import ExpDecay
+from quasielasticbayes.v2.functions.composite import CompositeFunction
+import numpy as np
+
+
+class FixedBG(LinearBG):
+    def __init__(self, prefix=''):
+        super().__init__(prefix)
+        self._N_params = 0
+        self._guess = []
+        self._lower = []
+        self._upper = []
+        self._c = 0
+        self._m = 0
+
+    def set_c(self, val):
+        self._c = val
+
+    def set_m(self, val):
+        self._m = val
+
+    def report(self, result):
+        return super().report(result, self._m, self._c)
+
+    def __call__(self, x):
+        return super().__call__(x, self._m, self._c)
+
+
+class FixedComposite(CompositeFunction):
+    def set_c(self, val):
+        # assume first entry is always fixed func
+        self._funcs[0].set_c(val)
+
+    def set_m(self, val):
+        # assume first entry is always fixed func
+        self._funcs[0].set_m(val)
+
+
+def gen_data():
+    x = np.linspace(1, 4, 100)
+    np.random.seed(1)
+    noise_stdev = 0.1
+    y = np.random.normal(0.5 + 0.2*x +
+                         1.2*np.exp(-2*x), noise_stdev)
+    e = 0.5*noise_stdev*np.ones(x.shape)
+    return x, y, e
+
+
+class SimpleWorkflow(GridSearchTemplate):
+    @staticmethod
+    def _update_function(func):
+        """
+        Add a flat BG term
+        """
+        ed = ExpDecay()
+        func.add_function(ed)
+        return func
+
+    @staticmethod
+    def set_x_value(func, value):
+        print(func, value)
+        func.set_c(value)
+        return func
+
+    @staticmethod
+    def set_y_value(func, value):
+        print(func)
+        func.set_m(value)
+        return func
+
+    @staticmethod
+    def N(func):
+        return 1
+
+
+class GridSearchTemplateTest(unittest.TestCase):
+
+    def setUp(self):
+        self.func = FixedComposite()
+        lin = FixedBG()
+        self.func.add_function(lin)
+        results = {}
+        errors = {}
+        self.wf = SimpleWorkflow(results, errors)
+
+    def test_set_x_axis(self):
+        self.wf.set_x_axis(1, 3, 5, 'test')
+        x_axis = self.wf.get_x_axis
+        expect = [1, 1.5, 2., 2.5, 3]
+        values = x_axis.values
+        self.assertEqual(len(values), len(expect))
+        for j in range(len(expect)):
+            self.assertEqual(values[j], expect[j])
+        self.assertEqual(x_axis.len, 5)
+        self.assertEqual(x_axis.label, "test")
+
+    def test_set_y_axis(self):
+        self.wf.set_y_axis(6, 8, 5, 'test2')
+        y_axis = self.wf.get_y_axis
+        expect = [6, 6.5, 7., 7.5, 8]
+        values = y_axis.values
+        self.assertEqual(len(values), len(expect))
+        for j in range(len(expect)):
+            self.assertEqual(values[j], expect[j])
+        self.assertEqual(y_axis.len, 5)
+        self.assertEqual(y_axis.label, "test2")
+
+    def test_grid(self):
+        self.wf.set_x_axis(0, 1, 2, 'x')
+        self.wf.set_y_axis(1, 2, 2, 'y')
+        X, Y = self.wf.generate_mesh()
+        grid = self.wf.get_grid
+
+        expect_x = [[0, 1], [0, 1]]
+        expect_y = [[1, 1], [2, 2]]
+
+        for i in range(2):
+            for j in range(2):
+                self.assertEqual(X[i][j], expect_x[i][j])
+                self.assertEqual(Y[i][j], expect_y[i][j])
+                self.assertEqual(grid[i][j], 0)
+
+    def test_preprocess_data(self):
+        # same
+        x, y, e = gen_data()
+        self.wf.preprocess_data(x, y, e)
+        self.assertEqual(len(self.wf._data), 3)
+        self.assertEqual(len(self.wf._data['x']), len(x))
+        self.assertEqual(len(self.wf._data['y']), len(y))
+        self.assertEqual(len(self.wf._data['e']), len(e))
+        for j in range(len(x)):
+            self.assertEqual(self.wf._data['x'][j], x[j])
+            self.assertEqual(self.wf._data['y'][j], y[j])
+            self.assertEqual(self.wf._data['e'][j], e[j])
+
+    def test_execute(self):
+        # indirectly tests normalise_grid and get_z_value
+
+        # setup workflow + generate data
+        x, y, e = gen_data()
+        self.wf.preprocess_data(x, y, e)
+        self.wf.set_x_axis(0, 1, 2, 'x')
+        self.wf.set_y_axis(1, 2, 2, 'y')
+        self.func.add_function(ExpDecay())
+        self.wf.set_scipy_engine([0, 0], [-9, -9], [9, 9])
+        results = {}
+        X, Y = self.wf.execute(self.func, results)
+
+        grid = self.wf.get_grid
+        expect_z = [[0.449, 1], [0, 0.115]]
+        expect_x = [[0, 1], [0, 1]]
+        expect_y = [[1, 1], [2, 2]]
+
+        for i in range(2):
+            for j in range(2):
+                self.assertEqual(X[i][j], expect_x[i][j])
+                self.assertEqual(Y[i][j], expect_y[i][j])
+                self.assertAlmostEqual(grid[i][j],
+                                       expect_z[i][j], 3)
+
+    def test_get_slices(self):
+        # setup workflow + generate data
+        x, y, e = gen_data()
+        self.wf.preprocess_data(x, y, e)
+        self.wf.set_x_axis(0, 1, 2, 'x')
+        self.wf.set_y_axis(1, 2, 2, 'y')
+        self.func.add_function(ExpDecay())
+        self.wf.set_scipy_engine([0, 0], [-9, -9], [9, 9])
+        results = {}
+        _, _ = self.wf.execute(self.func, results)
+
+        x, y = self.wf.get_slices()
+        expect_x = [0.449, 1]
+        expect_y = [1, 0.115]
+
+        self.assertEqual(len(x), len(expect_x))
+        self.assertEqual(len(y), len(expect_y))
+
+        for j in range(len(x)):
+            self.assertAlmostEqual(x[j], expect_x[j], 3)
+            self.assertAlmostEqual(y[j], expect_y[j], 3)
+
+    def test_get_parameters_and_errors(self):
+        # rm
+        pass
+
+    def test_fails_if_no_data(self):
+        # same
+        with self.assertRaises(ValueError):
+            self.wf.set_scipy_engine([0], [-9], [9])
+
+    def test_execute_no_engine(self):
+        x, y, e = gen_data()
+        self.wf.preprocess_data(x, y, e)
+        self.wf.set_x_axis(0, 1, 2, 'x')
+        self.wf.set_y_axis(1, 2, 2, 'y')
+        with self.assertRaises(ValueError):
+            _, _ = self.wf.execute(self.func, {})
+
+    def test_execute_no_x_axis(self):
+        x, y, e = gen_data()
+        self.wf.preprocess_data(x, y, e)
+        self.wf.set_y_axis(1, 2, 2, 'y')
+        with self.assertRaises(ValueError):
+            _, _ = self.wf.execute(self.func, {})
+
+    def test_execute_no_y_axis(self):
+        x, y, e = gen_data()
+        self.wf.preprocess_data(x, y, e)
+        self.wf.set_x_axis(0, 1, 2, 'x')
+        with self.assertRaises(ValueError):
+            _, _ = self.wf.execute(self.func, {})
+
+    def test_add_second_engine_errors(self):
+        x, y, e = gen_data()
+        self.wf.preprocess_data(x, y, e)
+        self.wf.set_x_axis(0, 1, 2, 'x')
+        self.wf.set_y_axis(1, 2, 2, 'y')
+        self.wf.set_scipy_engine([], [], [])
+        with self.assertRaises(RuntimeError):
+            self.wf.set_scipy_engine([], [], [])
+
+    def test_set_scipy_engine(self):
+        # same
+        self.assertEqual(self.wf.fit_engine, None)
+        x, y, e = gen_data()
+        self.wf.preprocess_data(x, y, e)
+        self.wf.set_scipy_engine([], [], [])
+        self.assertEqual(self.wf.fit_engine.name, 'scipy')
+
+    def test_update_scipy_fit_engine(self):
+        # same
+        self.assertEqual(self.wf.fit_engine, None)
+        x, y, e = gen_data()
+        self.wf.preprocess_data(x, y, e)
+        self.wf.set_scipy_engine([], [], [])
+        self.assertEqual(self.wf.fit_engine._guess, [])
+        self.assertEqual(self.wf.fit_engine._lower, [])
+        self.assertEqual(self.wf.fit_engine._upper, [])
+
+        bg = FlatBG()
+        self.wf.update_fit_engine(bg, [2])
+        self.assertEqual(self.wf.fit_engine._guess, [2])
+        self.assertEqual(self.wf.fit_engine._lower, [-1])
+        self.assertEqual(self.wf.fit_engine._upper, [1])
+
+    def test_set_gofit_engine(self):
+        # same
+        self.assertEqual(self.wf.fit_engine, None)
+        x, y, e = gen_data()
+        self.wf.preprocess_data(x, y, e)
+        self.wf.set_gofit_engine(5, [], [])
+        self.assertEqual(self.wf.fit_engine.name, 'gofit')
+
+    def test_update_gofit_engine(self):
+        # same
+        self.assertEqual(self.wf.fit_engine, None)
+        x, y, e = gen_data()
+        self.wf.preprocess_data(x, y, e)
+        self.wf.set_gofit_engine(5, [], [])
+        self.assertEqual(self.wf.fit_engine._lower, [])
+        self.assertEqual(self.wf.fit_engine._upper, [])
+
+        bg = FlatBG()
+        self.wf.update_fit_engine(bg, [5])
+        self.assertEqual(self.wf.fit_engine._lower, [-1])
+        self.assertEqual(self.wf.fit_engine._upper, [1])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/workflows/grid_search/quest_test.py
+++ b/test/workflows/grid_search/quest_test.py
@@ -46,9 +46,9 @@ class QuestTest(unittest.TestCase):
         X, Y = search.execute(func)
         grid = search.get_grid
 
-        # just check max value and indicies
+        # just check max value and indices
         max_val = np.max(grid)
-        indicies = np.where(grid == max_val)
+        indices = np.where(grid == max_val)
 
         self.assertEqual(max_val, 1.)
         self.assertEqual(indicies[0][0], 3)

--- a/test/workflows/grid_search/quest_test.py
+++ b/test/workflows/grid_search/quest_test.py
@@ -14,10 +14,7 @@ class QuestTest(unittest.TestCase):
         sx, sy, se = np.load(os.path.join(DATA_DIR, 'sample_data_red.npy'))
         rx, ry, re = np.load(os.path.join(DATA_DIR, 'qse_res.npy'),
                              allow_pickle=True)
-
         resolution = {'x': rx, 'y': ry}
-        results = {}
-        errors = {}
 
         # set values
         start_x = -0.5
@@ -32,7 +29,7 @@ class QuestTest(unittest.TestCase):
         FWHM_end = 0.056
 
         # create workflow
-        search = QSEGridSearch(results, errors)
+        search = QSEGridSearch()
         new_x, ry = search.preprocess_data(sx, sy, se, start_x, end_x,
                                            resolution)
         search.set_x_axis(beta_start, beta_end, N_beta, 'beta')
@@ -46,7 +43,7 @@ class QuestTest(unittest.TestCase):
 
         # do search
         search.set_scipy_engine(func.get_guess(), *func.get_bounds())
-        X, Y = search.execute(func, results)
+        X, Y = search.execute(func)
         grid = search.get_grid
 
         # just check max value and indicies

--- a/test/workflows/grid_search/quest_test.py
+++ b/test/workflows/grid_search/quest_test.py
@@ -1,0 +1,72 @@
+import unittest
+from quasielasticbayes.v2.functions.qse_fixed import QSEFixFunction
+from quasielasticbayes.v2.functions.BG import LinearBG
+from quasielasticbayes.v2.workflow.qse_search import QSEGridSearch
+import numpy as np
+import os.path
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), '..', '..', 'data')
+
+
+class QuestTest(unittest.TestCase):
+    def test_quest(self):
+        # get data
+        sx, sy, se = np.load(os.path.join(DATA_DIR, 'sample_data_red.npy'))
+        rx, ry, re = np.load(os.path.join(DATA_DIR, 'qse_res.npy'),
+                             allow_pickle=True)
+
+        resolution = {'x': rx, 'y': ry}
+        results = {}
+        errors = {}
+
+        # set values
+        start_x = -0.5
+        end_x = 0.5
+
+        N_beta = 5
+        beta_start = 0.75
+        beta_end = 0.78
+
+        N_FWHM = 5
+        FWHM_start = 0.055
+        FWHM_end = 0.056
+
+        # create workflow
+        search = QSEGridSearch(results, errors)
+        new_x, ry = search.preprocess_data(sx, sy, se, start_x, end_x,
+                                           resolution)
+        search.set_x_axis(beta_start, beta_end, N_beta, 'beta')
+        search.set_y_axis(FWHM_start, FWHM_end, N_FWHM, 'FWHM')
+
+        # create function
+        bg = LinearBG()
+        func = QSEFixFunction(bg, True, new_x, ry, start_x, end_x)
+        func.add_single_SE()
+        func.set_delta_bounds([0, -.5], [20, .5])
+
+        # do search
+        search.set_scipy_engine(func.get_guess(), *func.get_bounds())
+        X, Y = search.execute(func, results)
+        grid = search.get_grid
+
+        # just check max value and indicies
+        max_val = np.max(grid)
+        indicies = np.where(grid == max_val)
+
+        self.assertEqual(max_val, 1.)
+        self.assertEqual(indicies[0][0], 3)
+        self.assertEqual(indicies[1][0], 2)
+
+        beta_slice, FWHM_slice = search.get_slices()
+        expected_beta = [0.781, 0.971, 1.0, 0.904, 0.685]
+        expected_FWHM = [0.814, 0.910, 0.972, 1, 0.994]
+
+        self.assertEqual(len(beta_slice), len(expected_beta))
+        self.assertEqual(len(FWHM_slice), len(expected_FWHM))
+        for j in range(len(beta_slice)):
+            self.assertAlmostEqual(beta_slice[j], expected_beta[j], 3)
+            self.assertAlmostEqual(FWHM_slice[j], expected_FWHM[j], 3)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/workflows/grid_search/quest_test.py
+++ b/test/workflows/grid_search/quest_test.py
@@ -51,8 +51,8 @@ class QuestTest(unittest.TestCase):
         indices = np.where(grid == max_val)
 
         self.assertEqual(max_val, 1.)
-        self.assertEqual(indicies[0][0], 3)
-        self.assertEqual(indicies[1][0], 2)
+        self.assertEqual(indices[0][0], 3)
+        self.assertEqual(indices[1][0], 2)
 
         beta_slice, FWHM_slice = search.get_slices()
         expected_beta = [0.781, 0.971, 1.0, 0.904, 0.685]

--- a/test/workflows/model_selection/modelSelectionTemplate_test.py
+++ b/test/workflows/model_selection/modelSelectionTemplate_test.py
@@ -3,17 +3,7 @@ from quasielasticbayes.v2.workflow.model_template import ModelSelectionWorkflow
 from quasielasticbayes.v2.functions.BG import FlatBG
 from quasielasticbayes.v2.functions.exp_decay import ExpDecay
 from quasielasticbayes.v2.functions.composite import CompositeFunction
-import numpy as np
-
-
-def gen_data():
-    x = np.linspace(1, 4, 100)
-    np.random.seed(1)
-    noise_stdev = 0.1
-    y = np.random.normal(0.5 +
-                         1.2*np.exp(-2*x), noise_stdev)
-    e = 0.5*noise_stdev*np.ones(x.shape)
-    return x, y, e
+from quasielasticbayes.test_helpers.workflows import gen_model_selection_data
 
 
 class SimpleWorkflow(ModelSelectionWorkflow):
@@ -38,7 +28,7 @@ class WorkflowTemplateTest(unittest.TestCase):
         self.wf = SimpleWorkflow(results, errors)
 
     def test_preprocess_data(self):
-        x, y, e = gen_data()
+        x, y, e = gen_model_selection_data()
         self.wf.preprocess_data(x, y, e)
         self.assertEqual(len(self.wf._data), 3)
         self.assertEqual(len(self.wf._data['x']), len(x))
@@ -67,7 +57,7 @@ class WorkflowTemplateTest(unittest.TestCase):
         self.assertEqual(errors, {})
 
         # setup workflow + generate data
-        x, y, e = gen_data()
+        x, y, e = gen_model_selection_data()
         self.wf.preprocess_data(x, y, e)
         self.wf.set_scipy_engine([0], [-9], [9])
         _ = self.wf.execute(1, self.func)
@@ -96,13 +86,13 @@ class WorkflowTemplateTest(unittest.TestCase):
             self.wf.set_scipy_engine([0], [-9], [9])
 
     def test_execute_no_engine(self):
-        x, y, e = gen_data()
+        x, y, e = gen_model_selection_data()
         self.wf.preprocess_data(x, y, e)
         with self.assertRaises(ValueError):
             _ = self.wf.execute(1, self.func)
 
     def test_add_second_engine_errors(self):
-        x, y, e = gen_data()
+        x, y, e = gen_model_selection_data()
         self.wf.preprocess_data(x, y, e)
         self.wf.set_scipy_engine([0], [-9], [9])
         with self.assertRaises(RuntimeError):
@@ -110,14 +100,14 @@ class WorkflowTemplateTest(unittest.TestCase):
 
     def test_set_scipy_engine(self):
         self.assertEqual(self.wf.fit_engine, None)
-        x, y, e = gen_data()
+        x, y, e = gen_model_selection_data()
         self.wf.preprocess_data(x, y, e)
         self.wf.set_scipy_engine([], [], [])
         self.assertEqual(self.wf.fit_engine.name, 'scipy')
 
     def test_update_scipy_fit_engine(self):
         self.assertEqual(self.wf.fit_engine, None)
-        x, y, e = gen_data()
+        x, y, e = gen_model_selection_data()
         self.wf.preprocess_data(x, y, e)
         self.wf.set_scipy_engine([], [], [])
         self.assertEqual(self.wf.fit_engine._guess, [])
@@ -132,14 +122,14 @@ class WorkflowTemplateTest(unittest.TestCase):
 
     def test_set_gofit_engine(self):
         self.assertEqual(self.wf.fit_engine, None)
-        x, y, e = gen_data()
+        x, y, e = gen_model_selection_data()
         self.wf.preprocess_data(x, y, e)
         self.wf.set_gofit_engine(5, [], [])
         self.assertEqual(self.wf.fit_engine.name, 'gofit')
 
     def test_update_gofit_engine(self):
         self.assertEqual(self.wf.fit_engine, None)
-        x, y, e = gen_data()
+        x, y, e = gen_model_selection_data()
         self.wf.preprocess_data(x, y, e)
         self.wf.set_gofit_engine(5, [], [])
         self.assertEqual(self.wf.fit_engine._lower, [])

--- a/test/workflows/model_selection/modelSelectionTemplate_test.py
+++ b/test/workflows/model_selection/modelSelectionTemplate_test.py
@@ -1,5 +1,5 @@
 import unittest
-from quasielasticbayes.v2.workflow.template import Workflow
+from quasielasticbayes.v2.workflow.model_template import ModelSelectionWorkflow
 from quasielasticbayes.v2.functions.BG import FlatBG
 from quasielasticbayes.v2.functions.exp_decay import ExpDecay
 from quasielasticbayes.v2.functions.composite import CompositeFunction
@@ -16,7 +16,7 @@ def gen_data():
     return x, y, e
 
 
-class SimpleWorkflow(Workflow):
+class SimpleWorkflow(ModelSelectionWorkflow):
     @staticmethod
     def _update_function(func):
         """

--- a/test/workflows/model_selection/muonexpdecay_test.py
+++ b/test/workflows/model_selection/muonexpdecay_test.py
@@ -3,7 +3,7 @@ from quasielasticbayes.v2.workflow.MuonExpDecay import muon_expdecay_main
 import numpy as np
 import os.path
 
-DATA_DIR = os.path.join(os.path.dirname(__file__), '..', 'data')
+DATA_DIR = os.path.join(os.path.dirname(__file__), '..', '..', 'data')
 DATA_DIR = os.path.join(DATA_DIR, 'muon')
 
 

--- a/test/workflows/model_selection/qldatav2_test.py
+++ b/test/workflows/model_selection/qldatav2_test.py
@@ -5,7 +5,7 @@ from quasielasticbayes.v2.functions.BG import LinearBG
 import numpy as np
 import os.path
 
-DATA_DIR = os.path.join(os.path.dirname(__file__), '..', 'data')
+DATA_DIR = os.path.join(os.path.dirname(__file__), '..', '..', 'data')
 
 
 """

--- a/test/workflows/model_selection/qlsev2_test.py
+++ b/test/workflows/model_selection/qlsev2_test.py
@@ -5,7 +5,7 @@ from quasielasticbayes.v2.workflow.QSE import qse_data_main
 import numpy as np
 import os.path
 
-DATA_DIR = os.path.join(os.path.dirname(__file__), '..', 'data')
+DATA_DIR = os.path.join(os.path.dirname(__file__), '..', '..', 'data')
 
 
 """

--- a/v2_setup.py
+++ b/v2_setup.py
@@ -86,6 +86,16 @@ def get_v2_extensions(PACKAGE_NAME):
         f'{PACKAGE_NAME}.v2.workflow.MuonExpDecay':
             [join('workflows', 'muon_exp_decay_main.py')],
 
+        f'{PACKAGE_NAME}.v2.workflow.grid_template':
+            [join('workflows', 'grid_search',
+                  'grid_search_template.py')],
+        f'{PACKAGE_NAME}.v2.workflow.qse_search':
+            [join('workflows', 'grid_search',
+                  'qse_grid_search.py')],
+
+
+
+
         f'{PACKAGE_NAME}.v2.utils.general':
             [join('utils', 'general.py')],
         f'{PACKAGE_NAME}.v2.utils.spline':

--- a/v2_setup.py
+++ b/v2_setup.py
@@ -73,6 +73,9 @@ def get_v2_extensions(PACKAGE_NAME):
             [join('test_helpers', 'fitting_data.py')],
         f'{PACKAGE_NAME}.test_helpers.template_scipy_fit':
             [join('test_helpers', 'template_scipy_fit_test.py')],
+        f'{PACKAGE_NAME}.test_helpers.workflows':
+            [join('test_helpers', 'workflow_helper.py')],
+
 
         f'{PACKAGE_NAME}.v2.log_likelihood':
             ['log_likelihood.py'],
@@ -99,9 +102,6 @@ def get_v2_extensions(PACKAGE_NAME):
         f'{PACKAGE_NAME}.v2.workflow.qse_search':
             [join('workflows', 'grid_search',
                   'qse_grid_search.py')],
-
-
-
 
         f'{PACKAGE_NAME}.v2.utils.general':
             [join('utils', 'general.py')],

--- a/v2_setup.py
+++ b/v2_setup.py
@@ -54,6 +54,9 @@ def get_v2_extensions(PACKAGE_NAME):
             [join('fit_functions', 'qse.py')],
         f'{PACKAGE_NAME}.v2.functions.exp_decay':
             [join('fit_functions', 'exp_decay.py')],
+        f'{PACKAGE_NAME}.v2.functions.qse_fixed':
+            [join('fit_functions', 'qse_fixed.py')],
+
 
         f'{PACKAGE_NAME}.v2.fitting.fit_utils':
             [join('fit_engines', 'fit_utils.py')],

--- a/v2_setup.py
+++ b/v2_setup.py
@@ -46,6 +46,8 @@ def get_v2_extensions(PACKAGE_NAME):
             [join('fit_functions', 'qldata_function.py')],
         f'{PACKAGE_NAME}.v2.functions.qe_function':
             [join('fit_functions', 'quasielastic_function.py')],
+        f'{PACKAGE_NAME}.v2.functions.SE_fix':
+            [join('fit_functions', 'stretch_exp_fixed.py')],
         f'{PACKAGE_NAME}.v2.functions.SE':
             [join('fit_functions', 'stretch_exp.py')],
         f'{PACKAGE_NAME}.v2.functions.qse_function':

--- a/v2_setup.py
+++ b/v2_setup.py
@@ -79,12 +79,19 @@ def get_v2_extensions(PACKAGE_NAME):
 
         f'{PACKAGE_NAME}.v2.workflow.template':
             [join('workflows', 'workflow_template.py')],
+
+        f'{PACKAGE_NAME}.v2.workflow.model_template':
+            [join('workflows', 'model_selection',
+                  'model_template.py')],
         f'{PACKAGE_NAME}.v2.workflow.QlData':
-            [join('workflows', 'qldata_main.py')],
+            [join('workflows', 'model_selection',
+                  'qldata_main.py')],
         f'{PACKAGE_NAME}.v2.workflow.QSE':
-            [join('workflows', 'qse_main.py')],
+            [join('workflows', 'model_selection',
+                  'qse_main.py')],
         f'{PACKAGE_NAME}.v2.workflow.MuonExpDecay':
-            [join('workflows', 'muon_exp_decay_main.py')],
+            [join('workflows', 'model_selection',
+                  'muon_exp_decay_main.py')],
 
         f'{PACKAGE_NAME}.v2.workflow.grid_template':
             [join('workflows', 'grid_search',


### PR DESCRIPTION
This PR recreates the functionality of the Quest module in the Fortran code. In Mantid it is accessed via https://docs.mantidproject.org/nightly/algorithms/BayesStretch-v1.html

The Quest module did a grid search for the optimum beta and sigma (Full Width Half Maximum) values. It may give different results due to the Fortran code having a bug that underestimated the FWHM at low Q values. 

The code has been tested by Spencer and he is happy with the output:
![image](https://user-images.githubusercontent.com/25006392/227572716-632563ce-2578-4f9b-b95b-94ef35964430.png)

The red cross is the value from doing a fit with beta and FWHM unfixed
The green cross is the point with the maximum value (this will be different to the red cross as it can only exist on intersections of the grid, so depends on the sampling of the grid). The 2 line plots show slices through the green cross at constant beta and FWHM. 